### PR TITLE
Improve Azure platform detection

### DIFF
--- a/crates/attestation/src/azure/mod.rs
+++ b/crates/attestation/src/azure/mod.rs
@@ -9,6 +9,7 @@ use base64::{Engine as _, engine::general_purpose::URL_SAFE as BASE64_URL_SAFE};
 use dcap_qvl::QuoteCollateralV3;
 use num_bigint::BigUint;
 use openssl::{error::ErrorStack, pkey::PKey};
+use reqwest::header::CONTENT_TYPE;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use x509_parser::prelude::*;
@@ -272,21 +273,48 @@ impl RsaPubKey {
 }
 
 /// Detect whether we are on Azure and can make an Azure vTPM attestation
-pub async fn detect_azure_cvm() -> Result<bool, reqwest::Error> {
+pub async fn detect_azure_cvm() -> Result<bool, MaaError> {
     let client = reqwest::Client::builder().no_proxy().timeout(Duration::from_secs(2)).build()?;
 
-    let resp = client.get(AZURE_METADATA_API).header("Metadata", "true").send().await;
+    let response = match client.get(AZURE_METADATA_API).header("Metadata", "true").send().await {
+        Ok(response) => response,
+        Err(err) => {
+            tracing::debug!("Azure CVM detection failed: Azure metadata API request failed: {err}");
+            return Ok(false);
+        }
+    };
 
-    if let Ok(r) = resp &&
-        r.status().is_success() &&
-        r.headers()
-            .get(reqwest::header::CONTENT_TYPE)
-            .and_then(|value| value.to_str().ok())
-            .is_some_and(|value| value.starts_with("application/json"))
-    {
-        return Ok(az_tdx_vtpm::is_tdx_cvm().unwrap_or(false));
+    if !response.status().is_success() {
+        tracing::debug!(
+            "Azure CVM detection failed: metadata API returned non-success status: {}",
+            response.status()
+        );
+        return Ok(false);
     }
-    Ok(false)
+
+    // Ensure the response has a JSON content type
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .map(|value| value.to_str().map(str::to_owned))
+        .transpose()
+        .map_err(|_| MaaError::AzureMetadataApiNonJsonResponse { content_type: None })?;
+
+    if !content_type.as_deref().is_some_and(|value| value.starts_with("application/json")) {
+        return Err(MaaError::AzureMetadataApiNonJsonResponse { content_type });
+    }
+
+    match az_tdx_vtpm::is_tdx_cvm() {
+        Ok(true) => Ok(true),
+        Ok(false) => {
+            tracing::debug!("Azure CVM detection failed: platform is not an Azure TDX CVM");
+            Ok(false)
+        }
+        Err(err) => {
+            tracing::debug!("Azure CVM detection failed: Azure TDX CVM probe failed: {err}");
+            Ok(false)
+        }
+    }
 }
 
 /// An error when generating or verifying a Microsoft Azure vTPM attestation
@@ -302,6 +330,8 @@ pub enum MaaError {
     Hcl(#[from] hcl::HclError),
     #[error("JSON: {0}")]
     Json(#[from] serde_json::Error),
+    #[error("HTTP client: {0}")]
+    Reqwest(#[from] reqwest::Error),
     #[error("vTPM quote: {0}")]
     VtpmQuote(#[from] vtpm::QuoteError),
     #[error("AK public key: {0}")]
@@ -350,6 +380,10 @@ pub enum MaaError {
     ClaimsUserDataInputMismatch,
     #[error("DCAP verification: {0}")]
     DcapVerification(#[from] crate::dcap::DcapVerificationError),
+    #[error(
+        "Azure metadata API returned a successful response with non-JSON content-type: {content_type:?}"
+    )]
+    AzureMetadataApiNonJsonResponse { content_type: Option<String> },
 }
 
 #[cfg(test)]

--- a/crates/attestation/src/azure/mod.rs
+++ b/crates/attestation/src/azure/mod.rs
@@ -310,7 +310,7 @@ pub async fn detect_azure_cvm() -> Result<bool, MaaError> {
         .transpose()
         .map_err(|_| MaaError::AzureMetadataApiNonJsonResponse { content_type: None })?;
 
-    if !content_type.as_deref().is_some_and(|value| value.starts_with("application/json")) {
+    if !content_type.as_deref().is_some_and(|value| value.to_lowercase().starts_with("application/json")) {
         return Err(MaaError::AzureMetadataApiNonJsonResponse { content_type });
     }
 

--- a/crates/attestation/src/azure/mod.rs
+++ b/crates/attestation/src/azure/mod.rs
@@ -1,6 +1,8 @@
 //! Microsoft Azure vTPM attestation evidence generation and verification
 mod ak_certificate;
 mod nv_index;
+use std::time::Duration;
+
 use ak_certificate::{read_ak_certificate_from_tpm, verify_ak_cert_with_azure_roots};
 use az_tdx_vtpm::{hcl, imds, vtpm};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE as BASE64_URL_SAFE};
@@ -12,6 +14,9 @@ use thiserror::Error;
 use x509_parser::prelude::*;
 
 use crate::{dcap::verify_dcap_attestation_with_given_timestamp, measurements::MultiMeasurements};
+
+/// Used in attestation type detection to check if we are on Azure
+const AZURE_METADATA_API: &str = "http://169.254.169.254/metadata/instance";
 
 /// The attestation evidence payload that gets sent over the channel
 #[derive(Debug, Serialize, Deserialize)]
@@ -264,6 +269,24 @@ impl RsaPubKey {
             e: BigUint::from_bytes_be(&rsa_from_pkey.e().to_vec()),
         })
     }
+}
+
+/// Detect whether we are on Azure and can make an Azure vTPM attestation
+pub async fn detect_azure_cvm() -> Result<bool, reqwest::Error> {
+    let client = reqwest::Client::builder().no_proxy().timeout(Duration::from_secs(2)).build()?;
+
+    let resp = client.get(AZURE_METADATA_API).header("Metadata", "true").send().await;
+
+    if let Ok(r) = resp &&
+        r.status().is_success() &&
+        r.headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value.starts_with("application/json"))
+    {
+        return Ok(az_tdx_vtpm::is_tdx_cvm().unwrap_or(false));
+    }
+    Ok(false)
 }
 
 /// An error when generating or verifying a Microsoft Azure vTPM attestation

--- a/crates/attestation/src/azure/mod.rs
+++ b/crates/attestation/src/azure/mod.rs
@@ -310,7 +310,10 @@ pub async fn detect_azure_cvm() -> Result<bool, MaaError> {
         .transpose()
         .map_err(|_| MaaError::AzureMetadataApiNonJsonResponse { content_type: None })?;
 
-    if !content_type.as_deref().is_some_and(|value| value.to_lowercase().starts_with("application/json")) {
+    if !content_type
+        .as_deref()
+        .is_some_and(|value| value.to_lowercase().starts_with("application/json"))
+    {
         return Err(MaaError::AzureMetadataApiNonJsonResponse { content_type });
     }
 

--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -73,7 +73,7 @@ impl AttestationType {
         // First attempt azure, if the feature is present
         #[cfg(feature = "azure")]
         {
-            if azure::create_azure_attestation([0; 64]).is_ok() {
+            if azure::detect_azure_cvm().await? {
                 return Ok(AttestationType::AzureTdx);
             }
         }


### PR DESCRIPTION
Closes https://github.com/flashbots/attested-tls/issues/11

This aims to improve detection that we are on a TDX Azure instance.

Previously we attempted to do an Azure vTPM attestation and if it succeeds, assume we are on Azure.

Now we first hit the Azure metadata API, and if that succeeds, we call `az_tdx_vtpm::is_tdx_cvm()`](https://docs.rs/az-tdx-vtpm/latest/az_tdx_vtpm/fn.is_tdx_cvm.html) which internally gets an HCL report from the vTPM and checks that the report type is TDX.

The advantage of first hitting the metadata API is that we do not get errors logged when this fails on non-azure platforms.

Im not sure if there is an advantage of using `is_tdx_cvm()` rather than doing a full attestation.  It makes the check faster, but maybe does not fully guarantee that attestation will succeed.

I have not yet tested this on Azure.