### PR TITLE
misc updates and improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "x509-parser 0.18.1",
+ "webpki-roots 1.0.7",
+ "x509-parser 0.16.0",
  "yasna 0.5.2",
 ]
 
@@ -2007,7 +2008,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3365,7 +3366,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -4632,14 +4633,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,7 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "tss-esapi",
+ "ureq",
  "x509-parser 0.18.1",
 ]
 
@@ -2006,7 +2007,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3364,7 +3365,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4388,11 +4389,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
  "base64 0.22.1",
+ "flate2",
  "log",
  "once_cell",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4619,6 +4624,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/crates/attestation/Cargo.toml
+++ b/crates/attestation/Cargo.toml
@@ -26,6 +26,7 @@ base64 = "0.22.1"
 reqwest = { version = "0.12.23", default-features = false, features = [
   "rustls-tls-webpki-roots-no-provider",
 ] }
+ureq = "2.12.1"
 tracing = "0.1.41"
 parity-scale-codec = "3.7.5"
 num-bigint = "0.4.6"

--- a/crates/attestation/Cargo.toml
+++ b/crates/attestation/Cargo.toml
@@ -8,31 +8,30 @@ repository = "https://github.com/flashbots/attested-tls"
 keywords = ["attestation", "CVM", "TDX"]
 
 [dependencies]
+dcap-qvl = { workspace = true, features = ["danger-allow-tcb-override"] }
 pccs = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 tokio-rustls = { workspace = true, default-features = false }
-x509-parser = "0.18.0"
-thiserror = "2.0.17"
+
 anyhow = "1.0.100"
-pem-rfc7468 = { version = "0.7.0", features = ["std"] }
+base64 = "0.22.1"
 configfs-tsm = "0.0.2"
-rand_core = { version = "0.6.4", features = ["getrandom"] }
-dcap-qvl = { workspace = true, features = ["danger-allow-tcb-override"] }
 hex = "0.4.3"
 http = "1.3.1"
-serde_json = "1.0.145"
-serde = "1.0.228"
-base64 = "0.22.1"
-reqwest = { version = "0.12.23", default-features = false, features = [
-  "rustls-tls-webpki-roots-no-provider",
-] }
-ureq = "2.12.1"
-tracing = "0.1.41"
-parity-scale-codec = "3.7.5"
 num-bigint = "0.4.6"
-webpki = { package = "rustls-webpki", version = "0.103.8" }
-time = "0.3.47"
 once_cell = "1.21.3"
+parity-scale-codec = "3.7.5"
+pem-rfc7468 = { version = "0.7.0", features = ["std"] }
+rand_core = { version = "0.6.4", features = ["getrandom"] }
+reqwest = { version = "0.12.23", default-features = false, features = [ "rustls-tls-webpki-roots-no-provider" ] }
+serde = "1.0.228"
+serde_json = "1.0.145"
+thiserror = "2.0.17"
+time = "0.3.47"
+tracing = "0.1.41"
+ureq = "2.12.1"
+webpki = { package = "rustls-webpki", version = "0.103.8" }
+x509-parser = "0.18.0"
 
 # Used for azure vTPM attestation support
 az-tdx-vtpm = { version = "0.7.4", optional = true }
@@ -43,10 +42,11 @@ openssl = { version = "0.10.78", optional = true }
 tdx-quote = { version = "0.0.5", features = ["mock"], optional = true }
 
 [dev-dependencies]
-tempfile = "3.23.0"
-tdx-quote = { version = "0.0.5", features = ["mock"] }
 tokio-rustls = { workspace = true, default-features = true }
+
 serde-saphyr = "0.0.22"
+tdx-quote = { version = "0.0.5", features = ["mock"] }
+tempfile = "3.23.0"
 
 [features]
 default = []

--- a/crates/attestation/src/azure/mod.rs
+++ b/crates/attestation/src/azure/mod.rs
@@ -396,38 +396,32 @@ impl RsaPubKey {
 }
 
 /// Detect whether we are on Azure and can make an Azure vTPM attestation
-pub async fn detect_azure_cvm() -> Result<bool, MaaError> {
-    let client = reqwest::Client::builder().no_proxy().timeout(Duration::from_secs(2)).build()?;
-
-    let response = match client.get(AZURE_METADATA_API).header("Metadata", "true").send().await {
-        Ok(response) => response,
+pub fn detect_azure_cvm() -> Result<bool, MaaError> {
+    let agent = ureq::AgentBuilder::new().timeout(Duration::from_millis(200)).build();
+    let resp = match agent.get(AZURE_METADATA_API).set("Metadata", "true").call() {
+        Ok(resp) => resp,
         Err(err) => {
             tracing::debug!("Azure CVM detection failed: Azure metadata API request failed: {err}");
             return Ok(false);
         }
     };
 
-    if !response.status().is_success() {
+    if resp.status() != 200 {
         tracing::debug!(
             "Azure CVM detection failed: metadata API returned non-success status: {}",
-            response.status()
+            resp.status()
         );
         return Ok(false);
     }
 
     // Ensure the response has a JSON content type
-    let content_type = response
-        .headers()
-        .get(CONTENT_TYPE)
-        .map(|value| value.to_str().map(str::to_owned))
-        .transpose()
-        .map_err(|_| MaaError::AzureMetadataApiNonJsonResponse { content_type: None })?;
+    let content_type = resp
+        .header(CONTENT_TYPE.as_str())
+        .map(|value| value.to_owned())
+        .ok_or_else(|| MaaError::AzureMetadataApiNonJsonResponse { content_type: None })?;
 
-    if !content_type
-        .as_deref()
-        .is_some_and(|value| value.to_lowercase().starts_with("application/json"))
-    {
-        return Err(MaaError::AzureMetadataApiNonJsonResponse { content_type });
+    if !content_type.to_lowercase().starts_with("application/json") {
+        return Err(MaaError::AzureMetadataApiNonJsonResponse { content_type: Some(content_type) });
     }
 
     match az_tdx_vtpm::is_tdx_cvm() {

--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -7,6 +7,7 @@ pub mod measurements;
 
 use std::{
     fmt::{self, Display, Formatter},
+    io::Read,
     net::IpAddr,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -206,12 +207,12 @@ impl AttestationGenerator {
     }
 
     /// Generate an attestation exchange message with given input data
-    pub async fn generate_attestation(
+    pub fn generate_attestation(
         &self,
         input_data: [u8; 64],
     ) -> Result<AttestationExchangeMessage, AttestationError> {
         if let Some(url) = &self.attestation_provider_url {
-            Self::use_attestation_provider(url, self.attestation_type, input_data).await
+            Self::use_attestation_provider(url, self.attestation_type, input_data)
         } else {
             Ok(AttestationExchangeMessage {
                 attestation_type: self.attestation_type,
@@ -247,27 +248,29 @@ impl AttestationGenerator {
 
     /// Generate an attestation by using an external service for the
     /// attestation generation
-    async fn use_attestation_provider(
+    fn use_attestation_provider(
         url: &str,
         attestation_type: AttestationType,
         input_data: [u8; 64],
     ) -> Result<AttestationExchangeMessage, AttestationError> {
         let url = format!("{}/attest/{}", url, hex::encode(input_data));
 
-        let response = reqwest::get(url)
-            .await
+        let mut response = ureq::get(&url)
+            .timeout(Duration::from_millis(1000))
+            .call()
             .map_err(|err| AttestationError::AttestationProvider(err.to_string()))?
-            .bytes()
-            .await
-            .map_err(|err| AttestationError::AttestationProvider(err.to_string()))?
-            .to_vec();
+            .into_reader();
+        let mut body = Vec::new();
+        response
+            .read_to_end(&mut body)
+            .map_err(|err| AttestationError::AttestationProvider(err.to_string()))?;
 
         // If the response is not already wrapped in an attestation exchange
         // message, wrap it in one
-        if let Ok(message) = AttestationExchangeMessage::decode(&mut &response[..]) {
+        if let Ok(message) = AttestationExchangeMessage::decode(&mut &body[..]) {
             Ok(message)
         } else {
-            Ok(AttestationExchangeMessage { attestation_type, attestation: response })
+            Ok(AttestationExchangeMessage { attestation_type, attestation: body })
         }
     }
 }
@@ -498,14 +501,12 @@ fn log_attestation(attestation: &AttestationExchangeMessage) {
 /// Test whether it looks like we are running on GCP by hitting the metadata
 /// API
 fn running_on_gcp() -> Result<bool, AttestationError> {
-    let client =
-        reqwest::blocking::Client::builder().timeout(Duration::from_millis(200)).build()?;
-
-    let resp = client.get(GCP_METADATA_API).send();
+    let agent = ureq::AgentBuilder::new().timeout(Duration::from_millis(200)).build();
+    let resp = agent.get(GCP_METADATA_API).call();
 
     if let Ok(r) = resp {
-        return Ok(r.status().is_success() &&
-            r.headers().get("Metadata-Flavor").map(|v| v == "Google").unwrap_or(false));
+        return Ok(r.status() == 200 &&
+            r.header("Metadata-Flavor").map(|v| v == "Google").unwrap_or(false));
     }
 
     Ok(false)
@@ -645,7 +646,7 @@ mod tests {
         let _ = running_on_gcp();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn attestation_provider_response_is_wrapped_if_needed() {
         let input_data = [0u8; 64];
 
@@ -662,7 +663,6 @@ mod tests {
             AttestationType::GcpTdx,
             input_data,
         )
-        .await
         .unwrap();
         assert_eq!(decoded.attestation_type, AttestationType::None);
         assert_eq!(decoded.attestation, vec![1, 2, 3]);
@@ -674,7 +674,6 @@ mod tests {
             AttestationType::DcapTdx,
             input_data,
         )
-        .await
         .unwrap();
         assert_eq!(wrapped.attestation_type, AttestationType::DcapTdx);
         assert_eq!(wrapped.attestation, vec![9, 8]);

--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -633,12 +633,14 @@ mod tests {
         addr
     }
 
+    #[test]
     fn attestation_detection_does_not_panic() {
         // We dont enforce what platform the test is run on, only that the function
         // does not panic
         let _ = AttestationGenerator::new_with_detection(None, None);
     }
 
+    #[test]
     fn running_on_gcp_check_does_not_panic() {
         let _ = running_on_gcp();
     }

--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -103,18 +103,18 @@ impl AttestationType {
     }
 
     /// Detect what platform we are on by attempting an attestation
-    pub async fn detect() -> Result<Self, AttestationError> {
+    pub fn detect() -> Result<Self, AttestationError> {
         // First attempt azure, if the feature is present
         #[cfg(feature = "azure")]
         {
-            if azure::detect_azure_cvm().await? {
+            if azure::detect_azure_cvm()? {
                 return Ok(AttestationType::AzureTdx);
             }
         }
         // Otherwise try DCAP quote - this internally checks that the quote provider
         // is `tdx_guest`
         if configfs_tsm::create_tdx_quote([0; 64]).is_ok() {
-            if running_on_gcp().await? {
+            if running_on_gcp()? {
                 return Ok(AttestationType::GcpTdx);
             } else {
                 return Ok(AttestationType::DcapTdx);
@@ -170,8 +170,8 @@ impl AttestationGenerator {
 
     /// Detect what confidential compute platform is present and create the
     /// appropriate attestation generator
-    pub async fn detect() -> Result<Self, AttestationError> {
-        Self::new_with_detection(None, None).await
+    pub fn detect() -> Result<Self, AttestationError> {
+        Self::new_with_detection(None, None)
     }
 
     /// Do not generate attestations
@@ -181,7 +181,7 @@ impl AttestationGenerator {
 
     /// Create an [AttestationGenerator] detecting the attestation type if
     /// it is not given
-    pub async fn new_with_detection(
+    pub fn new_with_detection(
         attestation_type_string: Option<String>,
         attestation_provider_url: Option<String>,
     ) -> Result<Self, AttestationError> {
@@ -196,7 +196,7 @@ impl AttestationGenerator {
         let attestation_type_string = attestation_type_string.unwrap_or_else(|| "auto".to_string());
         let attestation_type = if attestation_type_string == "auto" {
             tracing::info!("Doing attestation type detection...");
-            AttestationType::detect().await?
+            AttestationType::detect()?
         } else {
             serde_json::from_value(serde_json::Value::String(attestation_type_string))?
         };
@@ -497,10 +497,11 @@ fn log_attestation(attestation: &AttestationExchangeMessage) {
 
 /// Test whether it looks like we are running on GCP by hitting the metadata
 /// API
-async fn running_on_gcp() -> Result<bool, AttestationError> {
-    let client = reqwest::Client::builder().timeout(Duration::from_millis(200)).build()?;
+fn running_on_gcp() -> Result<bool, AttestationError> {
+    let client =
+        reqwest::blocking::Client::builder().timeout(Duration::from_millis(200)).build()?;
 
-    let resp = client.get(GCP_METADATA_API).send().await;
+    let resp = client.get(GCP_METADATA_API).send();
 
     if let Ok(r) = resp {
         return Ok(r.status().is_success() &&
@@ -632,16 +633,14 @@ mod tests {
         addr
     }
 
-    #[tokio::test]
-    async fn attestation_detection_does_not_panic() {
+    fn attestation_detection_does_not_panic() {
         // We dont enforce what platform the test is run on, only that the function
         // does not panic
-        let _ = AttestationGenerator::new_with_detection(None, None).await;
+        let _ = AttestationGenerator::new_with_detection(None, None);
     }
 
-    #[tokio::test]
-    async fn running_on_gcp_check_does_not_panic() {
-        let _ = running_on_gcp().await;
+    fn running_on_gcp_check_does_not_panic() {
+        let _ = running_on_gcp();
     }
 
     #[tokio::test]

--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -55,7 +55,7 @@ impl AttestationExchangeMessage {
                     Err(AttestationError::AttestationTypeNotSupported)
                 }
             }
-            _ => {
+            AttestationType::DcapTdx | AttestationType::GcpTdx | AttestationType::QemuTdx => {
                 #[cfg(any(test, feature = "mock"))]
                 {
                     let quote = tdx_quote::Quote::from_bytes(&self.attestation)
@@ -242,7 +242,9 @@ impl AttestationGenerator {
                     Err(AttestationError::AttestationTypeNotSupported)
                 }
             }
-            _ => dcap::create_dcap_attestation(input_data),
+            AttestationType::DcapTdx | AttestationType::GcpTdx | AttestationType::QemuTdx => {
+                dcap::create_dcap_attestation(input_data)
+            }
         }
     }
 
@@ -394,7 +396,7 @@ impl AttestationVerifier {
                     return Err(AttestationError::AttestationTypeNotSupported);
                 }
             }
-            _ => {
+            AttestationType::DcapTdx | AttestationType::GcpTdx | AttestationType::QemuTdx => {
                 dcap::verify_dcap_attestation(
                     attestation_exchange_message.attestation,
                     expected_input_data,

--- a/crates/attestation/src/measurements.rs
+++ b/crates/attestation/src/measurements.rs
@@ -166,6 +166,7 @@ impl MultiMeasurements {
         let measurements_map: HashMap<u8, String> = serde_json::from_str(input)?;
 
         Ok(match attestation_type {
+            AttestationType::None => Self::NoAttestation,
             AttestationType::AzureTdx => Self::Azure(
                 measurements_map
                     .into_iter()
@@ -179,8 +180,7 @@ impl MultiMeasurements {
                     })
                     .collect::<Result<_, MeasurementFormatError>>()?,
             ),
-            AttestationType::None => Self::NoAttestation,
-            _ => {
+            AttestationType::DcapTdx | AttestationType::GcpTdx | AttestationType::QemuTdx => {
                 let measurements_map = measurements_map
                     .into_iter()
                     .map(|(k, v)| {
@@ -304,7 +304,9 @@ impl MeasurementRecord {
             measurements: match attestation_type {
                 AttestationType::None => ExpectedMeasurements::NoAttestation,
                 AttestationType::AzureTdx => ExpectedMeasurements::Azure(HashMap::new()),
-                _ => ExpectedMeasurements::Dcap(HashMap::new()),
+                AttestationType::DcapTdx | AttestationType::GcpTdx | AttestationType::QemuTdx => {
+                    ExpectedMeasurements::Dcap(HashMap::new())
+                }
             },
         }
     }
@@ -524,6 +526,7 @@ impl MeasurementPolicy {
 
             if let Some(measurements) = record.measurements {
                 let expected_measurements = match attestation_type {
+                    AttestationType::None => ExpectedMeasurements::NoAttestation,
                     AttestationType::AzureTdx => {
                         let azure_measurements = measurements
                             .iter()
@@ -535,8 +538,9 @@ impl MeasurementPolicy {
                             )?;
                         ExpectedMeasurements::Azure(azure_measurements)
                     }
-                    AttestationType::None => ExpectedMeasurements::NoAttestation,
-                    _ => ExpectedMeasurements::Dcap(
+                    AttestationType::DcapTdx |
+                    AttestationType::GcpTdx |
+                    AttestationType::QemuTdx => ExpectedMeasurements::Dcap(
                         measurements
                             .iter()
                             .map(|(index_str, entry)| {

--- a/crates/attested-tls/Cargo.toml
+++ b/crates/attested-tls/Cargo.toml
@@ -4,23 +4,26 @@ version = "0.0.1"
 edition = "2024"
 
 [dependencies]
-anyhow = "1.0.102"
 attestation = { workspace = true }
+rustls = { workspace = true, default-features = false }
+tokio = { workspace = true }
+
+anyhow = "1.0.102"
 ra-tls = { git = "https://github.com/Dstack-TEE/dstack.git", rev = "4f602dddc0542cd34da031c90ac0b3a560f316ed", features = ["quote"] }
 rcgen = "0.14.7"
-rustls = { workspace = true, default-features = false }
 serde_json = "1.0.149"
 sha2 = "0.10.9"
 thiserror = "2.0.17"
-tokio = { workspace = true }
 tracing = "0.1.41"
-x509-parser = "0.18.1"
+webpki-roots = "1.0.7"
+x509-parser = { version = "0.16", features = ["verify"] } # version must match the one from ra-tls
 yasna = "0.5.2"
 
 [dev-dependencies]
 attestation = { workspace = true, features = ["mock"] }
-nested-tls = { path = "../nested-tls" }
 rustls = { workspace = true, default-features = false, features = ["aws_lc_rs"] }
+
+nested-tls = { path = "../nested-tls" }
 
 [lints]
 workspace = true

--- a/crates/attested-tls/src/lib.rs
+++ b/crates/attested-tls/src/lib.rs
@@ -15,7 +15,7 @@ pub use attestation::{
 use ra_tls::{
     attestation::{Attestation, AttestationQuote, VersionedAttestation},
     cert::CertRequest,
-    rcgen::KeyPair,
+    rcgen::{KeyPair, PKCS_ECDSA_P256_SHA256},
 };
 pub use ra_tls::{cert::CaCert, rcgen};
 use rustls::{
@@ -110,72 +110,29 @@ impl fmt::Debug for ResolverState {
 }
 
 impl AttestedCertificateResolver {
-    /// Create a certificate resolver with a given attestation generator
-    /// A private certificate authority can also be given - otherwise
-    /// certificates will be self signed
-    pub fn new(
+    /// Create a default TLS certificate resolver wrapping given attestation
+    /// generator
+    pub fn try_default(
+        subject: &str,
         attestation_generator: AttestationGenerator,
-        key_pair: &KeyPair,
-        ca: Option<CaCert>,
-        subject: String,
-        subject_alt_names: Vec<String>,
-        certificate_validity_duration: Duration,
     ) -> Result<Self, AttestedTlsError> {
-        Self::new_with_provider(
-            attestation_generator,
-            key_pair,
-            ca,
-            subject,
-            subject_alt_names,
-            default_crypto_provider()?,
-            certificate_validity_duration,
-        )
+        Self::build(subject, attestation_generator).finish()
     }
 
-    /// Also provide a crypto provider
-    pub fn new_with_provider(
+    /// Build attested certificate resolver
+    pub fn build<'a, 'b>(
+        subject: &'b str,
         attestation_generator: AttestationGenerator,
-        key_pair: &KeyPair,
-        ca: Option<CaCert>,
-        subject: String,
-        subject_alt_names: Vec<String>,
-        provider: Arc<CryptoProvider>,
-        certificate_validity_duration: Duration,
-    ) -> Result<Self, AttestedTlsError> {
-        if certificate_validity_duration < MIN_CERTIFICATE_VALIDITY_DURATION {
-            return Err(AttestedTlsError::InvalidCertificateValidityDuration {
-                minimum: MIN_CERTIFICATE_VALIDITY_DURATION,
-            });
-        }
-        let subject_alt_names = normalized_subject_alt_names(subject.as_str(), subject_alt_names);
-
-        let key_pair_der = key_pair.serialize_der();
-        let key = Self::load_signing_key(key_pair, provider)?;
-
-        // Generate initial attested certificate
-        let certificate = Self::issue_ra_cert_chain(
-            key_pair,
-            ca.as_ref(),
-            subject.as_str(),
-            &subject_alt_names,
-            &attestation_generator,
-            certificate_validity_duration,
-        )?;
-
-        let state = Arc::new(ResolverState {
-            key,
-            certificate: RwLock::new(certificate),
-            ca: ca.map(Arc::new),
-            key_pair_der,
+    ) -> AttestedCertificateResolverBuilder<'a, 'b> {
+        AttestedCertificateResolverBuilder {
             attestation_generator,
+            ca_cert: None,
+            certificate_validity: Duration::from_millis(300000),
+            key_pair: None,
+            crypto_provider: None,
             subject,
-            subject_alt_names,
-        });
-
-        // Start a loop which will periodically renew the certificate
-        Self::spawn_renewal_task(Arc::downgrade(&state), certificate_validity_duration);
-
-        Ok(Self { state })
+            subject_alt_names: None,
+        }
     }
 
     /// Create an attested certificate chain - either self-signed or with
@@ -324,6 +281,114 @@ impl ResolvesServerCert for AttestedCertificateResolver {
     }
 }
 
+pub struct AttestedCertificateResolverBuilder<'a, 'b> {
+    /// Configured to generate attestations
+    attestation_generator: AttestationGenerator,
+    /// CA to sign leaf certificates
+    ca_cert: Option<CaCert>,
+    /// Duration of certificate validity
+    certificate_validity: Duration,
+    /// Key-pair to use
+    key_pair: Option<&'a KeyPair>,
+    /// Underlying cryptography provider
+    crypto_provider: Option<Arc<CryptoProvider>>,
+    /// Certificate subject
+    subject: &'b str,
+    // Subject alternative names
+    subject_alt_names: Option<Vec<String>>,
+}
+
+impl<'a, 'b> AttestedCertificateResolverBuilder<'a, 'b> {
+    /// Use specified CA to sign leaf certificates
+    pub fn with_ca_cert(mut self, ca: CaCert) -> Self {
+        self.ca_cert = Some(ca);
+        self
+    }
+
+    /// Set duration of certificates validity (default is 30 minutes)
+    pub fn with_certificate_validity(mut self, certificate_validity: Duration) -> Self {
+        self.certificate_validity = certificate_validity;
+        self
+    }
+
+    /// Use specified key-pair (default is to use randomly generated one)
+    pub fn with_key_pair(mut self, key_pair: &'a KeyPair) -> Self {
+        self.key_pair = Some(key_pair);
+        self
+    }
+
+    /// Use specified crypto provider
+    pub fn with_crypto_provider(mut self, provider: Arc<CryptoProvider>) -> Self {
+        self.crypto_provider = Some(provider.clone());
+        self
+    }
+
+    /// Use specified subject alternative names on generated certificates
+    pub fn with_subject_alt_names(mut self, subject_alt_names: Vec<String>) -> Self {
+        self.subject_alt_names = Some(subject_alt_names);
+        self
+    }
+
+    /// Finish the build of AttestedCertificateResolver
+    pub fn finish(self) -> Result<AttestedCertificateResolver, AttestedTlsError> {
+        let provider = match self.crypto_provider {
+            None => default_crypto_provider()?,
+            Some(provider) => provider,
+        };
+
+        if self.certificate_validity < MIN_CERTIFICATE_VALIDITY_DURATION {
+            return Err(AttestedTlsError::InvalidCertificateValidityDuration {
+                minimum: MIN_CERTIFICATE_VALIDITY_DURATION,
+            });
+        }
+
+        let key_pair = match self.key_pair {
+            None => {
+                &KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).map_err(AttestedTlsError::from)?
+            }
+            Some(key_pair) => key_pair,
+        };
+
+        let key_pair_der = key_pair.serialize_der();
+        let key = AttestedCertificateResolver::load_signing_key(key_pair, provider)?;
+
+        let subject_alt_names = match self.subject_alt_names {
+            None => vec![self.subject.to_owned()],
+            Some(subject_alt_names) => {
+                normalized_subject_alt_names(self.subject, subject_alt_names)
+            }
+        };
+
+        // Generate initial attested certificate
+        let certificate = AttestedCertificateResolver::issue_ra_cert_chain(
+            key_pair,
+            self.ca_cert.as_ref(),
+            self.subject,
+            &subject_alt_names,
+            &self.attestation_generator,
+            self.certificate_validity,
+        )?;
+
+        let state = Arc::new(ResolverState {
+            key,
+            certificate: RwLock::new(certificate),
+            ca: self.ca_cert.map(Arc::new),
+            key_pair_der,
+            attestation_generator: self.attestation_generator,
+            subject: self.subject.to_owned(),
+            subject_alt_names,
+        });
+
+        // Start a loop which will periodically renew the certificate
+        AttestedCertificateResolver::spawn_renewal_task(
+            Arc::downgrade(&state),
+            self.certificate_validity,
+        );
+
+        Ok(AttestedCertificateResolver { state })
+    }
+}
+
 impl ResolvesClientCert for AttestedCertificateResolver {
     fn resolve(&self, _: &[&[u8]], _: &[SignatureScheme]) -> Option<Arc<CertifiedKey>> {
         self.current_certified_key()
@@ -392,12 +457,12 @@ fn create_report_data(
 pub struct AttestedCertificateVerifier {
     /// Underlying verifier when used with a private CA rather than
     /// self-signed
-    server_inner: Option<Arc<WebPkiServerVerifier>>,
+    server_verifier: Option<Arc<WebPkiServerVerifier>>,
     /// Underlying client verifier when used with a private CA rather than
     /// self-signed
-    client_inner: Option<Arc<dyn ClientCertVerifier>>,
+    client_verifier: Option<Arc<dyn ClientCertVerifier>>,
     /// Underlying cryptography provider
-    provider: Arc<CryptoProvider>,
+    crypto_provider: Arc<CryptoProvider>,
     /// Configured for verifying attestations
     attestation_verifier: AttestationVerifier,
     /// Report data of pre-trusted certificates with cache expiry time
@@ -405,47 +470,28 @@ pub struct AttestedCertificateVerifier {
 }
 
 impl AttestedCertificateVerifier {
-    /// Create a certificate verifier with given attestation verification
-    /// and optionally a private CA root of trust
-    pub fn new(
-        root_store: Option<RootCertStore>,
+    /// Create a default TLS certificate verifier wrapping given attestation
+    /// verifier
+    pub fn try_default(
         attestation_verifier: AttestationVerifier,
     ) -> Result<Self, AttestedTlsError> {
-        Self::new_with_provider(root_store, attestation_verifier, default_crypto_provider()?)
-    }
-
-    /// Also provide a crypto provider
-    pub fn new_with_provider(
-        root_store: Option<RootCertStore>,
-        attestation_verifier: AttestationVerifier,
-        provider: Arc<CryptoProvider>,
-    ) -> Result<Self, AttestedTlsError> {
-        let (server_inner, client_inner) = match root_store {
-            Some(root_store) => {
-                let root_store = Arc::new(root_store);
-                let server_inner = WebPkiServerVerifier::builder_with_provider(
-                    root_store.clone(),
-                    provider.clone(),
-                )
-                .build()
-                .map_err(AttestedTlsError::VerifierBuilder)?;
-                let client_inner =
-                    WebPkiClientVerifier::builder_with_provider(root_store, provider.clone())
-                        .build()
-                        .map_err(AttestedTlsError::VerifierBuilder)?;
-
-                (Some(server_inner), Some(client_inner))
-            }
-            None => (None, None),
-        };
-
         Ok(Self {
-            server_inner,
-            client_inner,
-            provider,
+            server_verifier: None,
+            client_verifier: None,
+            crypto_provider: default_crypto_provider()?,
             attestation_verifier,
             trusted_certificates: Default::default(),
         })
+    }
+
+    /// Create a TLS certificate verifier wrapping given attestation
+    /// verifier
+    pub fn build(attestation_verifier: AttestationVerifier) -> AttestedCertificateVerifierBuilder {
+        AttestedCertificateVerifierBuilder {
+            root_cert_store: None,
+            crypto_provider: None,
+            attestation_verifier,
+        }
     }
 
     /// Given a TLS certificate, return the embedded attestation
@@ -661,7 +707,7 @@ impl ServerCertVerifier for AttestedCertificateVerifier {
         ocsp_response: &[u8],
         now: UnixTime,
     ) -> Result<ServerCertVerified, rustls::Error> {
-        if let Some(server_inner) = &self.server_inner {
+        if let Some(server_inner) = &self.server_verifier {
             server_inner.verify_server_cert(
                 end_entity,
                 intermediates,
@@ -686,7 +732,7 @@ impl ServerCertVerifier for AttestedCertificateVerifier {
             message,
             cert,
             dss,
-            &self.provider.signature_verification_algorithms,
+            &self.crypto_provider.signature_verification_algorithms,
         )
     }
 
@@ -700,16 +746,16 @@ impl ServerCertVerifier for AttestedCertificateVerifier {
             message,
             cert,
             dss,
-            &self.provider.signature_verification_algorithms,
+            &self.crypto_provider.signature_verification_algorithms,
         )
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        self.provider.signature_verification_algorithms.supported_schemes()
+        self.crypto_provider.signature_verification_algorithms.supported_schemes()
     }
 
     fn root_hint_subjects(&self) -> Option<&[DistinguishedName]> {
-        self.server_inner.as_ref().and_then(|server_inner| server_inner.root_hint_subjects())
+        self.server_verifier.as_ref().and_then(|server_inner| server_inner.root_hint_subjects())
     }
 }
 
@@ -725,7 +771,7 @@ impl ClientCertVerifier for AttestedCertificateVerifier {
     }
 
     fn root_hint_subjects(&self) -> &[DistinguishedName] {
-        self.client_inner.as_ref().map_or(&[], |client_inner| client_inner.root_hint_subjects())
+        self.client_verifier.as_ref().map_or(&[], |client_inner| client_inner.root_hint_subjects())
     }
 
     fn verify_client_cert(
@@ -734,7 +780,7 @@ impl ClientCertVerifier for AttestedCertificateVerifier {
         intermediates: &[CertificateDer<'_>],
         now: UnixTime,
     ) -> Result<ClientCertVerified, rustls::Error> {
-        if let Some(client_inner) = &self.client_inner {
+        if let Some(client_inner) = &self.client_verifier {
             client_inner.verify_client_cert(end_entity, intermediates, now)?;
         } else {
             Self::verify_cert_time_validity(end_entity, now)?;
@@ -753,7 +799,7 @@ impl ClientCertVerifier for AttestedCertificateVerifier {
             message,
             cert,
             dss,
-            &self.provider.signature_verification_algorithms,
+            &self.crypto_provider.signature_verification_algorithms,
         )
     }
 
@@ -767,12 +813,69 @@ impl ClientCertVerifier for AttestedCertificateVerifier {
             message,
             cert,
             dss,
-            &self.provider.signature_verification_algorithms,
+            &self.crypto_provider.signature_verification_algorithms,
         )
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        self.provider.signature_verification_algorithms.supported_schemes()
+        self.crypto_provider.signature_verification_algorithms.supported_schemes()
+    }
+}
+
+pub struct AttestedCertificateVerifierBuilder {
+    /// Configured for verifying attestations
+    attestation_verifier: AttestationVerifier,
+    /// Underlying cryptography provider
+    crypto_provider: Option<Arc<CryptoProvider>>,
+    // Custom root of trust
+    root_cert_store: Option<Arc<RootCertStore>>,
+}
+
+impl AttestedCertificateVerifierBuilder {
+    /// Use specified crypto provider
+    pub fn with_crypto_provider(mut self, provider: Arc<CryptoProvider>) -> Self {
+        self.crypto_provider = Some(provider.clone());
+        self
+    }
+
+    /// Use specified root of trust
+    pub fn with_root_cert_store(mut self, root_store: RootCertStore) -> Self {
+        self.root_cert_store = Some(Arc::new(root_store));
+        self
+    }
+
+    /// Finish the build of AttestedCertificateVerifier
+    pub fn finish(self) -> Result<AttestedCertificateVerifier, AttestedTlsError> {
+        let provider = match self.crypto_provider {
+            None => default_crypto_provider()?,
+            Some(provider) => provider,
+        };
+
+        let (server_inner, client_inner) = match self.root_cert_store {
+            Some(root_store) => {
+                let server_inner = WebPkiServerVerifier::builder_with_provider(
+                    root_store.clone(),
+                    provider.clone(),
+                )
+                .build()
+                .map_err(AttestedTlsError::VerifierBuilder)?;
+                let client_inner =
+                    WebPkiClientVerifier::builder_with_provider(root_store, provider.clone())
+                        .build()
+                        .map_err(AttestedTlsError::VerifierBuilder)?;
+
+                (Some(server_inner), Some(client_inner))
+            }
+            None => (None, None),
+        };
+
+        Ok(AttestedCertificateVerifier {
+            server_verifier: server_inner,
+            client_verifier: client_inner,
+            crypto_provider: provider,
+            attestation_verifier: self.attestation_verifier,
+            trusted_certificates: Default::default(),
+        })
     }
 }
 
@@ -865,15 +968,14 @@ mod tests {
     async fn certificate_resolver_creates_initial_certificate() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
-        let resolver = AttestedCertificateResolver::new_with_provider(
+        let resolver = AttestedCertificateResolver::build(
+            "foo",
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
-            &key_pair,
-            None,
-            "foo".to_string(),
-            vec![],
-            provider,
-            Duration::from_secs(4),
         )
+        .with_key_pair(&key_pair)
+        .with_crypto_provider(provider)
+        .with_certificate_validity(Duration::from_secs(4))
+        .finish()
         .unwrap();
 
         let certificate = resolver.state.certificate.read().unwrap();
@@ -885,15 +987,14 @@ mod tests {
     async fn certificate_resolver_rejects_too_short_validity_duration() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
-        let error = AttestedCertificateResolver::new_with_provider(
+        let error = AttestedCertificateResolver::build(
+            "foo",
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
-            &key_pair,
-            None,
-            "foo".to_string(),
-            vec![],
-            provider,
-            CERTIFICATE_RENEWAL_RETRY_DELAY * 3,
         )
+        .with_crypto_provider(provider)
+        .with_key_pair(&key_pair)
+        .with_certificate_validity(CERTIFICATE_RENEWAL_RETRY_DELAY * 3)
+        .finish()
         .unwrap_err();
 
         assert!(matches!(error, AttestedTlsError::InvalidCertificateValidityDuration { .. }));
@@ -904,23 +1005,20 @@ mod tests {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let server_name = "foo";
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
-        let resolver = AttestedCertificateResolver::new_with_provider(
+        let resolver = AttestedCertificateResolver::build(
+            server_name,
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
-            &key_pair,
-            None,
-            server_name.to_string(),
-            vec![],
-            provider.clone(),
-            Duration::from_secs(4),
         )
+        .with_crypto_provider(provider.clone())
+        .with_key_pair(&key_pair)
+        .with_certificate_validity(Duration::from_secs(4))
+        .finish()
         .unwrap();
 
-        let verifier = AttestedCertificateVerifier::new_with_provider(
-            None,
-            AttestationVerifier::mock(),
-            provider.clone(),
-        )
-        .unwrap();
+        let verifier = AttestedCertificateVerifier::build(AttestationVerifier::mock())
+            .with_crypto_provider(provider.clone())
+            .finish()
+            .unwrap();
 
         let server_config = ServerConfig::builder_with_provider(provider.clone())
             .with_safe_default_protocol_versions()
@@ -959,15 +1057,15 @@ mod tests {
         let ca = test_ca();
         let ca_cert = CertificateDer::from_pem_slice(ca.pem_cert.as_bytes()).unwrap();
 
-        let resolver = AttestedCertificateResolver::new_with_provider(
+        let resolver = AttestedCertificateResolver::build(
+            server_name,
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
-            &key_pair,
-            Some(ca),
-            server_name.to_string(),
-            vec![],
-            provider.clone(),
-            Duration::from_secs(4),
         )
+        .with_crypto_provider(provider.clone())
+        .with_key_pair(&key_pair)
+        .with_ca_cert(ca)
+        .with_certificate_validity(Duration::from_secs(4))
+        .finish()
         .unwrap();
 
         let certificate_chain = resolver.state.certificate.read().unwrap().clone();
@@ -977,12 +1075,11 @@ mod tests {
         let mut roots = RootCertStore::empty();
         roots.add(ca_cert).unwrap();
 
-        let verifier = AttestedCertificateVerifier::new_with_provider(
-            Some(roots),
-            AttestationVerifier::mock(),
-            provider.clone(),
-        )
-        .unwrap();
+        let verifier = AttestedCertificateVerifier::build(AttestationVerifier::mock())
+            .with_crypto_provider(provider.clone())
+            .with_root_cert_store(roots)
+            .finish()
+            .unwrap();
 
         let server_config = ServerConfig::builder_with_provider(provider.clone())
             .with_safe_default_protocol_versions()
@@ -1018,15 +1115,14 @@ mod tests {
     async fn certificate_is_renewed_before_expiry() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
-        let resolver = AttestedCertificateResolver::new_with_provider(
+        let resolver = AttestedCertificateResolver::build(
+            "foo",
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
-            &key_pair,
-            None,
-            "foo".to_string(),
-            vec![],
-            provider,
-            Duration::from_secs(4),
         )
+        .with_crypto_provider(provider.clone())
+        .with_key_pair(&key_pair)
+        .with_certificate_validity(Duration::from_secs(4))
+        .finish()
         .unwrap();
         let initial_certificate =
             resolver.state.certificate.read().unwrap().first().unwrap().clone();
@@ -1045,40 +1141,34 @@ mod tests {
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
         let server_name = "foo";
 
-        let server_resolver = AttestedCertificateResolver::new_with_provider(
+        let server_resolver = AttestedCertificateResolver::build(
+            server_name,
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
-            &key_pair,
-            None,
-            server_name.to_string(),
-            vec![],
-            provider.clone(),
-            Duration::from_secs(4),
         )
+        .with_crypto_provider(provider.clone())
+        .with_key_pair(&key_pair)
+        .with_certificate_validity(Duration::from_secs(4))
+        .finish()
         .unwrap();
 
-        let client_resolver = AttestedCertificateResolver::new_with_provider(
+        let client_resolver = AttestedCertificateResolver::build(
+            "client",
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
-            &key_pair,
-            None,
-            "client".to_string(),
-            vec![],
-            provider.clone(),
-            Duration::from_secs(4),
         )
+        .with_crypto_provider(provider.clone())
+        .with_key_pair(&key_pair)
+        .with_certificate_validity(Duration::from_secs(4))
+        .finish()
         .unwrap();
 
-        let server_verifier = AttestedCertificateVerifier::new_with_provider(
-            None,
-            AttestationVerifier::mock(),
-            provider.clone(),
-        )
-        .unwrap();
-        let client_verifier = AttestedCertificateVerifier::new_with_provider(
-            None,
-            AttestationVerifier::mock(),
-            provider.clone(),
-        )
-        .unwrap();
+        let server_verifier = AttestedCertificateVerifier::build(AttestationVerifier::mock())
+            .with_crypto_provider(provider.clone())
+            .finish()
+            .unwrap();
+        let client_verifier = AttestedCertificateVerifier::build(AttestationVerifier::mock())
+            .with_crypto_provider(provider.clone())
+            .finish()
+            .unwrap();
 
         let server_config = ServerConfig::builder_with_provider(provider.clone())
             .with_safe_default_protocol_versions()
@@ -1116,22 +1206,20 @@ mod tests {
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
         let subject = "foo";
         let alternate_name = "bar";
-        let resolver = AttestedCertificateResolver::new_with_provider(
+        let resolver = AttestedCertificateResolver::build(
+            subject,
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
-            &key_pair,
-            None,
-            subject.to_string(),
-            vec![alternate_name.to_string(), subject.to_string()],
-            provider.clone(),
-            Duration::from_secs(4),
         )
+        .with_subject_alt_names(vec![alternate_name.to_string(), subject.to_string()])
+        .with_crypto_provider(provider.clone())
+        .with_key_pair(&key_pair)
+        .with_certificate_validity(Duration::from_secs(4))
+        .finish()
         .unwrap();
-        let verifier = AttestedCertificateVerifier::new_with_provider(
-            None,
-            AttestationVerifier::mock(),
-            provider.clone(),
-        )
-        .unwrap();
+        let verifier = AttestedCertificateVerifier::build(AttestationVerifier::mock())
+            .with_crypto_provider(provider.clone())
+            .finish()
+            .unwrap();
 
         let server_config = ServerConfig::builder_with_provider(provider.clone())
             .with_safe_default_protocol_versions()
@@ -1164,12 +1252,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn malformed_certificate_returns_bad_encoding() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
-        let verifier = AttestedCertificateVerifier::new_with_provider(
-            None,
-            AttestationVerifier::mock(),
-            provider,
-        )
-        .unwrap();
+        let verifier = AttestedCertificateVerifier::build(AttestationVerifier::mock())
+            .with_crypto_provider(provider)
+            .finish()
+            .unwrap();
         let cert = CertificateDer::from(vec![1_u8, 2, 3, 4]);
 
         let result = verify_server_cert_direct(
@@ -1188,12 +1274,11 @@ mod tests {
         let cert = plain_self_signed_certificate("foo");
         let mut roots = RootCertStore::empty();
         roots.add(cert.clone()).unwrap();
-        let verifier = AttestedCertificateVerifier::new_with_provider(
-            Some(roots),
-            AttestationVerifier::mock(),
-            provider,
-        )
-        .unwrap();
+        let verifier = AttestedCertificateVerifier::build(AttestationVerifier::mock())
+            .with_crypto_provider(provider)
+            .with_root_cert_store(roots)
+            .finish()
+            .unwrap();
 
         let result = verify_server_cert_direct(
             &verifier,
@@ -1210,26 +1295,23 @@ mod tests {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let ca = test_ca();
         let ca_cert = CertificateDer::from_pem_slice(ca.pem_cert.as_bytes()).unwrap();
-        let resolver = AttestedCertificateResolver::new_with_provider(
+        let resolver = AttestedCertificateResolver::build(
+            "foo",
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
-            None,
-            "foo".to_string(),
-            vec![],
-            provider.clone(),
-            Duration::from_secs(4),
         )
-        .await
+        .with_crypto_provider(provider.clone())
+        .with_certificate_validity(Duration::from_secs(4))
+        .finish()
         .unwrap();
         let cert = resolver.state.certificate.read().unwrap().first().unwrap().clone();
 
         let mut roots = RootCertStore::empty();
         roots.add(ca_cert).unwrap();
-        let verifier = AttestedCertificateVerifier::new_with_provider(
-            Some(roots),
-            AttestationVerifier::mock(),
-            provider,
-        )
-        .unwrap();
+        let verifier = AttestedCertificateVerifier::build(AttestationVerifier::mock())
+            .with_crypto_provider(provider)
+            .with_root_cert_store(roots)
+            .finish()
+            .unwrap();
 
         let result = verify_server_cert_direct(
             &verifier,
@@ -1246,26 +1328,23 @@ mod tests {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let ca = test_ca();
         let ca_cert = CertificateDer::from_pem_slice(ca.pem_cert.as_bytes()).unwrap();
-        let resolver = AttestedCertificateResolver::new_with_provider(
+        let resolver = AttestedCertificateResolver::build(
+            "client",
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
-            None,
-            "client".to_string(),
-            vec![],
-            provider.clone(),
-            Duration::from_secs(4),
         )
-        .await
+        .with_crypto_provider(provider.clone())
+        .with_certificate_validity(Duration::from_secs(4))
+        .finish()
         .unwrap();
         let cert = resolver.state.certificate.read().unwrap().first().unwrap().clone();
 
         let mut roots = RootCertStore::empty();
         roots.add(ca_cert).unwrap();
-        let verifier = AttestedCertificateVerifier::new_with_provider(
-            Some(roots),
-            AttestationVerifier::mock(),
-            provider,
-        )
-        .unwrap();
+        let verifier = AttestedCertificateVerifier::build(AttestationVerifier::mock())
+            .with_crypto_provider(provider)
+            .with_root_cert_store(roots)
+            .finish()
+            .unwrap();
 
         let result = verify_client_cert_direct(&verifier, &cert, UnixTime::now());
 
@@ -1276,22 +1355,19 @@ mod tests {
     async fn self_signed_attested_certificate_with_wrong_name_is_rejected() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
-        let resolver = AttestedCertificateResolver::new_with_provider(
+        let resolver = AttestedCertificateResolver::build(
+            "foo",
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
-            &key_pair,
-            None,
-            "foo".to_string(),
-            vec![],
-            provider.clone(),
-            Duration::from_secs(4),
         )
+        .with_crypto_provider(provider.clone())
+        .with_key_pair(&key_pair)
+        .with_certificate_validity(Duration::from_secs(4))
+        .finish()
         .unwrap();
-        let verifier = AttestedCertificateVerifier::new_with_provider(
-            None,
-            AttestationVerifier::mock(),
-            provider,
-        )
-        .unwrap();
+        let verifier = AttestedCertificateVerifier::build(AttestationVerifier::mock())
+            .with_crypto_provider(provider)
+            .finish()
+            .unwrap();
         let cert = resolver.state.certificate.read().unwrap().first().unwrap().clone();
 
         let result = verify_server_cert_direct(
@@ -1311,15 +1387,14 @@ mod tests {
     async fn certificate_binding_changes_when_identity_changes() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
-        let resolver = AttestedCertificateResolver::new_with_provider(
+        let resolver = AttestedCertificateResolver::build(
+            "foo",
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
-            &key_pair,
-            None,
-            "foo".to_string(),
-            vec![],
-            provider.clone(),
-            Duration::from_secs(4),
         )
+        .with_crypto_provider(provider.clone())
+        .with_key_pair(&key_pair)
+        .with_certificate_validity(Duration::from_secs(4))
+        .finish()
         .unwrap();
         let original_cert = resolver.state.certificate.read().unwrap().first().unwrap().clone();
         let (original_report_data, original_not_after) =
@@ -1353,22 +1428,19 @@ mod tests {
     async fn attestation_rejection_returns_application_verification_failure() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
-        let resolver = AttestedCertificateResolver::new_with_provider(
+        let resolver = AttestedCertificateResolver::build(
+            "foo",
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
-            &key_pair,
-            None,
-            "foo".to_string(),
-            vec![],
-            provider.clone(),
-            Duration::from_secs(4),
         )
+        .with_crypto_provider(provider.clone())
+        .with_key_pair(&key_pair)
+        .with_certificate_validity(Duration::from_secs(4))
+        .finish()
         .unwrap();
-        let verifier = AttestedCertificateVerifier::new_with_provider(
-            None,
-            AttestationVerifier::expect_none(),
-            provider,
-        )
-        .unwrap();
+        let verifier = AttestedCertificateVerifier::build(AttestationVerifier::expect_none())
+            .with_crypto_provider(provider)
+            .finish()
+            .unwrap();
         let cert = resolver.state.certificate.read().unwrap().first().unwrap().clone();
 
         let result = verify_server_cert_direct(
@@ -1388,22 +1460,19 @@ mod tests {
     async fn verifier_reuses_trusted_certificate_cache() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
-        let resolver = AttestedCertificateResolver::new_with_provider(
+        let resolver = AttestedCertificateResolver::build(
+            "foo",
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
-            &key_pair,
-            None,
-            "foo".to_string(),
-            vec![],
-            provider.clone(),
-            Duration::from_secs(4),
         )
+        .with_crypto_provider(provider.clone())
+        .with_key_pair(&key_pair)
+        .with_certificate_validity(Duration::from_secs(4))
+        .finish()
         .unwrap();
-        let mut verifier = AttestedCertificateVerifier::new_with_provider(
-            None,
-            AttestationVerifier::mock(),
-            provider,
-        )
-        .unwrap();
+        let mut verifier = AttestedCertificateVerifier::build(AttestationVerifier::mock())
+            .with_crypto_provider(provider)
+            .finish()
+            .unwrap();
         let cert = resolver.state.certificate.read().unwrap().first().unwrap().clone();
         let (expected_input_data, not_after) =
             AttestedCertificateVerifier::cert_binding_data(&cert).unwrap();

--- a/crates/attested-tls/src/lib.rs
+++ b/crates/attested-tls/src/lib.rs
@@ -113,7 +113,7 @@ impl AttestedCertificateResolver {
     /// Create a certificate resolver with a given attestation generator
     /// A private certificate authority can also be given - otherwise
     /// certificates will be self signed
-    pub async fn new(
+    pub fn new(
         attestation_generator: AttestationGenerator,
         key_pair: &KeyPair,
         ca: Option<CaCert>,
@@ -130,11 +130,10 @@ impl AttestedCertificateResolver {
             default_crypto_provider()?,
             certificate_validity_duration,
         )
-        .await
     }
 
     /// Also provide a crypto provider
-    pub async fn new_with_provider(
+    pub fn new_with_provider(
         attestation_generator: AttestationGenerator,
         key_pair: &KeyPair,
         ca: Option<CaCert>,
@@ -161,8 +160,7 @@ impl AttestedCertificateResolver {
             &subject_alt_names,
             &attestation_generator,
             certificate_validity_duration,
-        )
-        .await?;
+        )?;
 
         let state = Arc::new(ResolverState {
             key,
@@ -182,7 +180,7 @@ impl AttestedCertificateResolver {
 
     /// Create an attested certificate chain - either self-signed or with
     /// the provided CA
-    async fn issue_ra_cert_chain(
+    fn issue_ra_cert_chain(
         key_pair: &KeyPair,
         ca: Option<&CaCert>,
         subject: &str,
@@ -201,8 +199,7 @@ impl AttestedCertificateResolver {
             not_after,
             subject,
             attestation_generator,
-        )
-        .await?;
+        )?;
 
         let cert_request = CertRequest::builder()
             .key(key_pair)
@@ -240,7 +237,7 @@ impl AttestedCertificateResolver {
 
     /// Create an attestation, and format it to be used in certificate
     /// extension
-    async fn create_attestation_payload(
+    fn create_attestation_payload(
         pubkey: Vec<u8>,
         not_before: SystemTime,
         not_after: SystemTime,
@@ -248,7 +245,7 @@ impl AttestedCertificateResolver {
         attestation_generator: &AttestationGenerator,
     ) -> Result<VersionedAttestation, AttestedTlsError> {
         let report_data = create_report_data(pubkey, not_before, not_after, subject.as_bytes())?;
-        let attestation = attestation_generator.generate_attestation(report_data).await?;
+        let attestation = attestation_generator.generate_attestation(report_data)?;
         Ok(VersionedAttestation::V0 {
             attestation: Attestation {
                 quote: ra_tls::attestation::AttestationQuote::DstackTdx(
@@ -297,9 +294,7 @@ impl AttestedCertificateResolver {
                     &current.subject_alt_names,
                     &current.attestation_generator,
                     certificate_validity_duration,
-                )
-                .await
-                {
+                ) {
                     Ok(certificate) => {
                         *current.certificate.write().expect("Certificate lock poisoned") =
                             certificate;
@@ -879,7 +874,6 @@ mod tests {
             provider,
             Duration::from_secs(4),
         )
-        .await
         .unwrap();
 
         let certificate = resolver.state.certificate.read().unwrap();
@@ -900,7 +894,6 @@ mod tests {
             provider,
             CERTIFICATE_RENEWAL_RETRY_DELAY * 3,
         )
-        .await
         .unwrap_err();
 
         assert!(matches!(error, AttestedTlsError::InvalidCertificateValidityDuration { .. }));
@@ -920,7 +913,6 @@ mod tests {
             provider.clone(),
             Duration::from_secs(4),
         )
-        .await
         .unwrap();
 
         let verifier = AttestedCertificateVerifier::new_with_provider(
@@ -976,7 +968,6 @@ mod tests {
             provider.clone(),
             Duration::from_secs(4),
         )
-        .await
         .unwrap();
 
         let certificate_chain = resolver.state.certificate.read().unwrap().clone();
@@ -1036,7 +1027,6 @@ mod tests {
             provider,
             Duration::from_secs(4),
         )
-        .await
         .unwrap();
         let initial_certificate =
             resolver.state.certificate.read().unwrap().first().unwrap().clone();
@@ -1064,7 +1054,6 @@ mod tests {
             provider.clone(),
             Duration::from_secs(4),
         )
-        .await
         .unwrap();
 
         let client_resolver = AttestedCertificateResolver::new_with_provider(
@@ -1076,7 +1065,6 @@ mod tests {
             provider.clone(),
             Duration::from_secs(4),
         )
-        .await
         .unwrap();
 
         let server_verifier = AttestedCertificateVerifier::new_with_provider(
@@ -1137,7 +1125,6 @@ mod tests {
             provider.clone(),
             Duration::from_secs(4),
         )
-        .await
         .unwrap();
         let verifier = AttestedCertificateVerifier::new_with_provider(
             None,
@@ -1298,7 +1285,6 @@ mod tests {
             provider.clone(),
             Duration::from_secs(4),
         )
-        .await
         .unwrap();
         let verifier = AttestedCertificateVerifier::new_with_provider(
             None,
@@ -1334,7 +1320,6 @@ mod tests {
             provider.clone(),
             Duration::from_secs(4),
         )
-        .await
         .unwrap();
         let original_cert = resolver.state.certificate.read().unwrap().first().unwrap().clone();
         let (original_report_data, original_not_after) =
@@ -1377,7 +1362,6 @@ mod tests {
             provider.clone(),
             Duration::from_secs(4),
         )
-        .await
         .unwrap();
         let verifier = AttestedCertificateVerifier::new_with_provider(
             None,
@@ -1413,7 +1397,6 @@ mod tests {
             provider.clone(),
             Duration::from_secs(4),
         )
-        .await
         .unwrap();
         let mut verifier = AttestedCertificateVerifier::new_with_provider(
             None,

--- a/crates/attested-tls/src/lib.rs
+++ b/crates/attested-tls/src/lib.rs
@@ -88,7 +88,7 @@ struct ResolverState {
     /// Attestation generator used when renewing certificate
     attestation_generator: AttestationGenerator,
     /// Primary DNS name used as certificate subject / common name.
-    primary_name: String,
+    subject: String,
     /// DNS subject alternative names, including the primary name.
     subject_alt_names: Vec<String>,
 }
@@ -103,7 +103,7 @@ impl fmt::Debug for ResolverState {
             .field("key_pair_der_len", &self.key_pair_der.len())
             .field("certificate_chain_len", &certificate_chain_len)
             .field("attestation_generator", &self.attestation_generator)
-            .field("primary_name", &self.primary_name)
+            .field("subject", &self.subject)
             .field("subject_alt_names", &self.subject_alt_names)
             .finish()
     }
@@ -116,14 +116,14 @@ impl AttestedCertificateResolver {
     pub async fn new(
         attestation_generator: AttestationGenerator,
         ca: Option<CaCert>,
-        primary_name: String,
+        subject: String,
         subject_alt_names: Vec<String>,
         certificate_validity_duration: Duration,
     ) -> Result<Self, AttestedTlsError> {
         Self::new_with_provider(
             attestation_generator,
             ca,
-            primary_name,
+            subject,
             subject_alt_names,
             default_crypto_provider()?,
             certificate_validity_duration,
@@ -135,7 +135,7 @@ impl AttestedCertificateResolver {
     pub async fn new_with_provider(
         attestation_generator: AttestationGenerator,
         ca: Option<CaCert>,
-        primary_name: String,
+        subject: String,
         subject_alt_names: Vec<String>,
         provider: Arc<CryptoProvider>,
         certificate_validity_duration: Duration,
@@ -145,8 +145,7 @@ impl AttestedCertificateResolver {
                 minimum: MIN_CERTIFICATE_VALIDITY_DURATION,
             });
         }
-        let subject_alt_names =
-            normalized_subject_alt_names(primary_name.as_str(), subject_alt_names);
+        let subject_alt_names = normalized_subject_alt_names(subject.as_str(), subject_alt_names);
 
         // Generate keypair
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)?;
@@ -157,7 +156,7 @@ impl AttestedCertificateResolver {
         let certificate = Self::issue_ra_cert_chain(
             &key_pair,
             ca.as_ref(),
-            primary_name.as_str(),
+            subject.as_str(),
             &subject_alt_names,
             &attestation_generator,
             certificate_validity_duration,
@@ -170,7 +169,7 @@ impl AttestedCertificateResolver {
             ca: ca.map(Arc::new),
             key_pair_der,
             attestation_generator,
-            primary_name,
+            subject,
             subject_alt_names,
         });
 
@@ -185,12 +184,12 @@ impl AttestedCertificateResolver {
     async fn issue_ra_cert_chain(
         key: &KeyPair,
         ca: Option<&CaCert>,
-        primary_name: &str,
+        subject: &str,
         subject_alt_names: &[String],
         attestation_generator: &AttestationGenerator,
         certificate_validity_duration: Duration,
     ) -> Result<Vec<CertificateDer<'static>>, AttestedTlsError> {
-        tracing::debug!("Generating new remote-attested certificate for {primary_name}");
+        tracing::debug!("Generating new remote-attested certificate for {subject}");
         let pubkey = key.public_key_der();
         let now = SystemTime::now();
         let not_after = now + certificate_validity_duration;
@@ -199,14 +198,14 @@ impl AttestedCertificateResolver {
             pubkey,
             now,
             not_after,
-            primary_name,
+            subject,
             attestation_generator,
         )
         .await?;
 
         let cert_request = CertRequest::builder()
             .key(key)
-            .subject(primary_name)
+            .subject(subject)
             .alt_names(subject_alt_names)
             .not_before(now)
             .not_after(not_after)
@@ -244,11 +243,10 @@ impl AttestedCertificateResolver {
         pubkey: Vec<u8>,
         not_before: SystemTime,
         not_after: SystemTime,
-        primary_name: &str,
+        subject: &str,
         attestation_generator: &AttestationGenerator,
     ) -> Result<VersionedAttestation, AttestedTlsError> {
-        let report_data =
-            create_report_data(pubkey, not_before, not_after, primary_name.as_bytes())?;
+        let report_data = create_report_data(pubkey, not_before, not_after, subject.as_bytes())?;
         let attestation = attestation_generator.generate_attestation(report_data).await?;
         Ok(VersionedAttestation::V0 {
             attestation: Attestation {
@@ -294,7 +292,7 @@ impl AttestedCertificateResolver {
                 next_delay = match Self::issue_ra_cert_chain(
                     &key_pair,
                     current.ca.as_deref(),
-                    current.primary_name.as_str(),
+                    current.subject.as_str(),
                     &current.subject_alt_names,
                     &current.attestation_generator,
                     certificate_validity_duration,
@@ -352,9 +350,9 @@ fn default_crypto_provider() -> Result<Arc<CryptoProvider>, AttestedTlsError> {
 }
 
 /// Ensures that SAN contains the primary hostname
-fn normalized_subject_alt_names(primary_name: &str, subject_alt_names: Vec<String>) -> Vec<String> {
+fn normalized_subject_alt_names(subject: &str, subject_alt_names: Vec<String>) -> Vec<String> {
     let mut normalized = Vec::with_capacity(subject_alt_names.len() + 1);
-    normalized.push(primary_name.to_string());
+    normalized.push(subject.to_string());
 
     for name in subject_alt_names {
         if !normalized.iter().any(|existing| existing == &name) {
@@ -1107,13 +1105,13 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn alternate_san_completes_a_handshake() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
-        let primary_name = "foo";
+        let subject = "foo";
         let alternate_name = "bar";
         let resolver = AttestedCertificateResolver::new_with_provider(
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
             None,
-            primary_name.to_string(),
-            vec![alternate_name.to_string(), primary_name.to_string()],
+            subject.to_string(),
+            vec![alternate_name.to_string(), subject.to_string()],
             provider.clone(),
             Duration::from_secs(4),
         )

--- a/crates/attested-tls/src/lib.rs
+++ b/crates/attested-tls/src/lib.rs
@@ -16,7 +16,7 @@ pub use ra_tls::cert::CaCert;
 use ra_tls::{
     attestation::{Attestation, AttestationQuote, VersionedAttestation},
     cert::CertRequest,
-    rcgen::{KeyPair, PKCS_ECDSA_P256_SHA256},
+    rcgen::KeyPair,
 };
 use rustls::{
     DigitallySignedStruct,
@@ -115,6 +115,7 @@ impl AttestedCertificateResolver {
     /// certificates will be self signed
     pub async fn new(
         attestation_generator: AttestationGenerator,
+        key_pair: &KeyPair,
         ca: Option<CaCert>,
         subject: String,
         subject_alt_names: Vec<String>,
@@ -122,6 +123,7 @@ impl AttestedCertificateResolver {
     ) -> Result<Self, AttestedTlsError> {
         Self::new_with_provider(
             attestation_generator,
+            key_pair,
             ca,
             subject,
             subject_alt_names,
@@ -134,6 +136,7 @@ impl AttestedCertificateResolver {
     /// Also provide a crypto provider
     pub async fn new_with_provider(
         attestation_generator: AttestationGenerator,
+        key_pair: &KeyPair,
         ca: Option<CaCert>,
         subject: String,
         subject_alt_names: Vec<String>,
@@ -147,14 +150,12 @@ impl AttestedCertificateResolver {
         }
         let subject_alt_names = normalized_subject_alt_names(subject.as_str(), subject_alt_names);
 
-        // Generate keypair
-        let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)?;
         let key_pair_der = key_pair.serialize_der();
-        let key = Self::load_signing_key(&key_pair, provider)?;
+        let key = Self::load_signing_key(key_pair, provider)?;
 
         // Generate initial attested certificate
         let certificate = Self::issue_ra_cert_chain(
-            &key_pair,
+            key_pair,
             ca.as_ref(),
             subject.as_str(),
             &subject_alt_names,
@@ -182,7 +183,7 @@ impl AttestedCertificateResolver {
     /// Create an attested certificate chain - either self-signed or with
     /// the provided CA
     async fn issue_ra_cert_chain(
-        key: &KeyPair,
+        key_pair: &KeyPair,
         ca: Option<&CaCert>,
         subject: &str,
         subject_alt_names: &[String],
@@ -190,7 +191,7 @@ impl AttestedCertificateResolver {
         certificate_validity_duration: Duration,
     ) -> Result<Vec<CertificateDer<'static>>, AttestedTlsError> {
         tracing::debug!("Generating new remote-attested certificate for {subject}");
-        let pubkey = key.public_key_der();
+        let pubkey = key_pair.public_key_der();
         let now = SystemTime::now();
         let not_after = now + certificate_validity_duration;
 
@@ -204,7 +205,7 @@ impl AttestedCertificateResolver {
         .await?;
 
         let cert_request = CertRequest::builder()
-            .key(key)
+            .key(key_pair)
             .subject(subject)
             .alt_names(subject_alt_names)
             .not_before(now)
@@ -814,7 +815,13 @@ pub enum AttestedTlsError {
 mod tests {
     use std::{io::Cursor, sync::Arc};
 
-    use ra_tls::rcgen::{BasicConstraints, CertificateParams, IsCa};
+    use ra_tls::rcgen::{
+        BasicConstraints,
+        CertificateParams,
+        IsCa,
+        KeyPair,
+        PKCS_ECDSA_P256_SHA256,
+    };
     use rustls::{
         CertificateError,
         ClientConfig,
@@ -862,8 +869,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn certificate_resolver_creates_initial_certificate() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
+        let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
         let resolver = AttestedCertificateResolver::new_with_provider(
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
+            &key_pair,
             None,
             "foo".to_string(),
             vec![],
@@ -881,8 +890,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn certificate_resolver_rejects_too_short_validity_duration() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
+        let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
         let error = AttestedCertificateResolver::new_with_provider(
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
+            &key_pair,
             None,
             "foo".to_string(),
             vec![],
@@ -899,8 +910,10 @@ mod tests {
     async fn server_and_client_configs_complete_a_handshake() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let server_name = "foo";
+        let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
         let resolver = AttestedCertificateResolver::new_with_provider(
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
+            &key_pair,
             None,
             server_name.to_string(),
             vec![],
@@ -949,12 +962,14 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn ca_signed_server_and_client_configs_complete_a_handshake() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
+        let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
         let server_name = "foo";
         let ca = test_ca();
         let ca_cert = CertificateDer::from_pem_slice(ca.pem_cert.as_bytes()).unwrap();
 
         let resolver = AttestedCertificateResolver::new_with_provider(
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
+            &key_pair,
             Some(ca),
             server_name.to_string(),
             vec![],
@@ -1011,8 +1026,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn certificate_is_renewed_before_expiry() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
+        let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
         let resolver = AttestedCertificateResolver::new_with_provider(
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
+            &key_pair,
             None,
             "foo".to_string(),
             vec![],
@@ -1035,10 +1052,12 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn server_and_client_configs_complete_a_mutual_auth_handshake() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
+        let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
         let server_name = "foo";
 
         let server_resolver = AttestedCertificateResolver::new_with_provider(
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
+            &key_pair,
             None,
             server_name.to_string(),
             vec![],
@@ -1050,6 +1069,7 @@ mod tests {
 
         let client_resolver = AttestedCertificateResolver::new_with_provider(
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
+            &key_pair,
             None,
             "client".to_string(),
             vec![],
@@ -1105,10 +1125,12 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn alternate_san_completes_a_handshake() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
+        let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
         let subject = "foo";
         let alternate_name = "bar";
         let resolver = AttestedCertificateResolver::new_with_provider(
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
+            &key_pair,
             None,
             subject.to_string(),
             vec![alternate_name.to_string(), subject.to_string()],
@@ -1266,8 +1288,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn self_signed_attested_certificate_with_wrong_name_is_rejected() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
+        let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
         let resolver = AttestedCertificateResolver::new_with_provider(
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
+            &key_pair,
             None,
             "foo".to_string(),
             vec![],
@@ -1300,8 +1324,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn certificate_binding_changes_when_identity_changes() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
+        let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
         let resolver = AttestedCertificateResolver::new_with_provider(
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
+            &key_pair,
             None,
             "foo".to_string(),
             vec![],
@@ -1341,8 +1367,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn attestation_rejection_returns_application_verification_failure() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
+        let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
         let resolver = AttestedCertificateResolver::new_with_provider(
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
+            &key_pair,
             None,
             "foo".to_string(),
             vec![],
@@ -1375,8 +1403,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn verifier_reuses_trusted_certificate_cache() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
+        let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
         let resolver = AttestedCertificateResolver::new_with_provider(
             AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
+            &key_pair,
             None,
             "foo".to_string(),
             vec![],

--- a/crates/attested-tls/src/lib.rs
+++ b/crates/attested-tls/src/lib.rs
@@ -12,12 +12,12 @@ pub use attestation::{
     AttestationType,
     AttestationVerifier,
 };
-pub use ra_tls::cert::CaCert;
 use ra_tls::{
     attestation::{Attestation, AttestationQuote, VersionedAttestation},
     cert::CertRequest,
     rcgen::KeyPair,
 };
+pub use ra_tls::{cert::CaCert, rcgen};
 use rustls::{
     DigitallySignedStruct,
     DistinguishedName,

--- a/crates/attested-tls/src/lib.rs
+++ b/crates/attested-tls/src/lib.rs
@@ -671,19 +671,14 @@ impl AttestedCertificateVerifier {
 
         let attestation = Self::extract_custom_attestation_from_cert(cert)?;
 
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                self.attestation_verifier
-                    .verify_attestation(attestation, expected_input_data)
-                    .await
-                    .map_err(|err| {
-                        tracing::warn!(
-                            "Rejecting certificate after attestation verification failure: {err}"
-                        );
-                        InvalidCertificate(CertificateError::ApplicationVerificationFailure)
-                    })
-            })
-        })?;
+        self.attestation_verifier
+            .verify_attestation_sync(attestation, expected_input_data)
+            .map_err(|err| {
+                tracing::warn!(
+                    "Rejecting certificate after attestation verification failure: {err}"
+                );
+                InvalidCertificate(CertificateError::ApplicationVerificationFailure)
+            })?;
 
         let mut trusted_certs = self.trusted_certs.write().map_err(|_| {
             rustls::Error::General("Trusted certificate cache lock poisoned".into())

--- a/crates/attested-tls/src/lib.rs
+++ b/crates/attested-tls/src/lib.rs
@@ -19,8 +19,10 @@ use ra_tls::{
 };
 pub use ra_tls::{cert::CaCert, rcgen};
 use rustls::{
+    CertificateError,
     DigitallySignedStruct,
     DistinguishedName,
+    Error::InvalidCertificate,
     RootCertStore,
     SignatureScheme,
     client::{
@@ -455,32 +457,60 @@ fn create_report_data(
 /// Verifies attested TLS server or client certificates during TLS handshake
 #[derive(Debug)]
 pub struct AttestedCertificateVerifier {
-    /// Underlying verifier when used with a private CA rather than
-    /// self-signed
-    server_verifier: Option<Arc<WebPkiServerVerifier>>,
-    /// Underlying client verifier when used with a private CA rather than
-    /// self-signed
-    client_verifier: Option<Arc<dyn ClientCertVerifier>>,
+    /// Underlying server certificates verifier
+    server_verifier: Arc<WebPkiServerVerifier>,
+    /// Underlying client certificates verifier (when used with a private CA
+    /// rather than self-signed)
+    client_verifier: Arc<dyn ClientCertVerifier>,
     /// Underlying cryptography provider
     crypto_provider: Arc<CryptoProvider>,
     /// Configured for verifying attestations
     attestation_verifier: AttestationVerifier,
     /// Report data of pre-trusted certificates with cache expiry time
-    trusted_certificates: Arc<RwLock<HashMap<[u8; 64], UnixTime>>>,
+    trusted_certs: Arc<RwLock<HashMap<[u8; 64], UnixTime>>>,
+    /// Whether self-signed certificates should be accepted
+    accept_self_signed_certs: bool,
+    /// SHA512 hashes of ASN.1 DER representations of public keys allowed
+    /// for leaf certificates
+    ///
+    /// Note: `None` means default behaviour, that is any public key for
+    ///       leaf certificates is acceptable as long as the certificate
+    ///       and its embedded attestation are valid
+    allowed_leaf_cert_pubkeys: Option<Arc<Vec<[u8; 64]>>>,
 }
 
 impl AttestedCertificateVerifier {
-    /// Create a default TLS certificate verifier wrapping given attestation
+    /// Create default TLS certificate verifier wrapping given attestation
     /// verifier
     pub fn try_default(
         attestation_verifier: AttestationVerifier,
     ) -> Result<Self, AttestedTlsError> {
+        let crypto_provider = default_crypto_provider()?;
+
+        let server_verifier = WebPkiServerVerifier::builder(Arc::new({
+            let mut root_cert_store = rustls::RootCertStore::empty();
+            root_cert_store.extend(webpki_roots::TLS_SERVER_ROOTS.to_owned());
+            root_cert_store
+        }))
+        .build()
+        .map_err(AttestedTlsError::VerifierBuilder)?;
+
+        let client_verifier = WebPkiClientVerifier::builder(Arc::new({
+            let mut root_cert_store = rustls::RootCertStore::empty();
+            root_cert_store.extend(webpki_roots::TLS_SERVER_ROOTS.to_owned());
+            root_cert_store
+        }))
+        .build()
+        .map_err(AttestedTlsError::VerifierBuilder)?;
+
         Ok(Self {
-            server_verifier: None,
-            client_verifier: None,
-            crypto_provider: default_crypto_provider()?,
+            server_verifier,
+            client_verifier,
+            crypto_provider,
             attestation_verifier,
-            trusted_certificates: Default::default(),
+            trusted_certs: Default::default(),
+            accept_self_signed_certs: true,
+            allowed_leaf_cert_pubkeys: None,
         })
     }
 
@@ -491,14 +521,16 @@ impl AttestedCertificateVerifier {
             root_cert_store: None,
             crypto_provider: None,
             attestation_verifier,
+            accept_self_signed_certs: true,
+            allowed_leaf_cert_pubkeys: None,
         }
     }
 
     /// Given a TLS certificate, return the embedded attestation
     pub fn extract_custom_attestation_from_cert(
-        cert: &CertificateDer<'_>,
+        cert: &X509Certificate<'_>,
     ) -> Result<AttestationExchangeMessage, rustls::Error> {
-        if let Ok(Some(attestation)) = ra_tls::attestation::from_der(cert.as_ref()) &&
+        if let Ok(Some(attestation)) = ra_tls::attestation::from_cert(cert) &&
             let AttestationQuote::DstackTdx(tdx_quote) = attestation.quote
         {
             if let Ok(message) =
@@ -514,9 +546,8 @@ impl AttestedCertificateVerifier {
         }
 
         // If that fails, extract and parse the extension
-        let cert = Self::parse_x509_certificate(cert)?;
         let oid = Oid::from(ra_tls::oids::PHALA_RATLS_TDX_QUOTE)
-            .map_err(|err| rustls::Error::General(format!("invalid attestation OID: {err}")))?;
+            .map_err(|err| rustls::Error::General(format!("invalid attestation OID: {err:?}")))?;
         let ext = cert
             .get_extension_unique(&oid)
             .map_err(|err| Self::bad_encoding(format!("invalid attestation extension: {err}")))?
@@ -529,8 +560,9 @@ impl AttestedCertificateVerifier {
 
     /// Given a certificate, return the attestation report input data based
     /// on public key and expiry, as well as the expiry time
-    fn cert_binding_data(cert: &CertificateDer<'_>) -> Result<([u8; 64], UnixTime), rustls::Error> {
-        let cert = Self::parse_x509_certificate(cert)?;
+    fn cert_binding_data(
+        cert: &X509Certificate<'_>,
+    ) -> Result<([u8; 64], UnixTime), rustls::Error> {
         let not_before: u64 = cert
             .validity()
             .not_before
@@ -543,7 +575,7 @@ impl AttestedCertificateVerifier {
             .timestamp()
             .try_into()
             .map_err(|_| rustls::Error::General("invalid certificate not_after".into()))?;
-        let hostname = Self::hostname_from_cert(&cert)?;
+        let hostname = Self::hostname_from_cert(cert)?;
         let expected_input_data = create_report_data(
             cert.public_key().raw.to_vec(),
             SystemTime::UNIX_EPOCH + Duration::from_secs(not_before),
@@ -556,19 +588,9 @@ impl AttestedCertificateVerifier {
         Ok((expected_input_data, not_after))
     }
 
-    /// Given a certificate and the current time, check if it is currently
-    /// valid
-    fn verify_cert_time_validity(
-        cert: &CertificateDer<'_>,
-        now: UnixTime,
-    ) -> Result<(), rustls::Error> {
-        let cert = Self::parse_x509_certificate(cert)?;
-        Self::verify_cert_time_validity_parsed(&cert, now)
-    }
-
     /// Given a parsed certificate and the current time, check if it is
     /// currently valid
-    fn verify_cert_time_validity_parsed(
+    fn verify_cert_time_validity(
         cert: &X509Certificate<'_>,
         now: UnixTime,
     ) -> Result<(), rustls::Error> {
@@ -587,60 +609,67 @@ impl AttestedCertificateVerifier {
             .map_err(|_| rustls::Error::General("invalid certificate not_after".into()))?;
 
         if now < not_before {
-            return Err(rustls::Error::InvalidCertificate(
-                rustls::CertificateError::NotValidYetContext {
-                    time: UnixTime::since_unix_epoch(Duration::from_secs(now)),
-                    not_before: UnixTime::since_unix_epoch(Duration::from_secs(not_before)),
-                },
-            ));
+            return Err(InvalidCertificate(CertificateError::NotValidYetContext {
+                time: UnixTime::since_unix_epoch(Duration::from_secs(now)),
+                not_before: UnixTime::since_unix_epoch(Duration::from_secs(not_before)),
+            }));
         }
 
         if now > not_after {
-            return Err(rustls::Error::InvalidCertificate(
-                rustls::CertificateError::ExpiredContext {
-                    time: UnixTime::since_unix_epoch(Duration::from_secs(now)),
-                    not_after: UnixTime::since_unix_epoch(Duration::from_secs(not_after)),
-                },
-            ));
+            return Err(InvalidCertificate(CertificateError::ExpiredContext {
+                time: UnixTime::since_unix_epoch(Duration::from_secs(now)),
+                not_after: UnixTime::since_unix_epoch(Duration::from_secs(not_after)),
+            }));
         }
 
         Ok(())
     }
 
-    /// Verify server name and time validity for self-signed certs
-    fn verify_server_cert_constraints(
-        cert: &CertificateDer<'_>,
-        server_name: &ServerName<'_>,
+    /// Check if the certificate is self-signed and verify it if it is
+    fn try_verifying_self_signed_cert(
+        &self,
+        cert: &X509Certificate<'_>,
         now: UnixTime,
     ) -> Result<(), rustls::Error> {
-        let parsed = ParsedCertificate::try_from(cert)?;
-        let cert = Self::parse_x509_certificate(cert)?;
-        Self::verify_cert_time_validity_parsed(&cert, now)?;
-        verify_server_name(&parsed, server_name)
+        if cert.subject() != cert.issuer() {
+            // issuer != subject means it's not a self-signed cert, so we just return
+            // the error as-is
+            return Err(InvalidCertificate(CertificateError::UnknownIssuer));
+        }
+
+        // verify the signature
+        cert.verify_signature(None)
+            .inspect_err(|err| tracing::warn!("invalid self-signed certificate signature: {err:?}"))
+            .map_err(|_| CertificateError::BadSignature)?;
+
+        // verify cert-time
+        Self::verify_cert_time_validity(cert, now)?;
+
+        Ok(())
     }
 
     /// Given a certificate with embedded attestation, verify the
     /// attestation if it has not already been verified
     fn verify_attestation_binding(
         &self,
-        end_entity: &CertificateDer<'_>,
+        cert: &X509Certificate<'_>,
         now: UnixTime,
     ) -> Result<(), rustls::Error> {
-        let (expected_input_data, expiry) = Self::cert_binding_data(end_entity)?;
+        let (expected_input_data, expiry) = Self::cert_binding_data(cert)?;
 
         // First check if we have already successfully verified the attestation
         // associated with this certificate
         {
-            let trusted_certificates = self.trusted_certificates.read().map_err(|_| {
+            let trusted_certs = self.trusted_certs.read().map_err(|_| {
                 rustls::Error::General("Trusted certificate cache lock poisoned".into())
             })?;
-            if trusted_certificates.get(&expected_input_data).is_some_and(|expiry| *expiry >= now) {
+            if trusted_certs.get(&expected_input_data).is_some_and(|expiry| *expiry >= now) {
                 tracing::debug!("Skipping attestation verification for trusted certificate");
                 return Ok(());
             }
         }
 
-        let attestation = Self::extract_custom_attestation_from_cert(end_entity)?;
+        let attestation = Self::extract_custom_attestation_from_cert(cert)?;
 
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
@@ -651,21 +680,19 @@ impl AttestedCertificateVerifier {
                         tracing::warn!(
                             "Rejecting certificate after attestation verification failure: {err}"
                         );
-                        rustls::Error::InvalidCertificate(
-                            rustls::CertificateError::ApplicationVerificationFailure,
-                        )
+                        InvalidCertificate(CertificateError::ApplicationVerificationFailure)
                     })
             })
         })?;
 
-        let mut trusted_certificates = self.trusted_certificates.write().map_err(|_| {
+        let mut trusted_certs = self.trusted_certs.write().map_err(|_| {
             rustls::Error::General("Trusted certificate cache lock poisoned".into())
         })?;
 
         // Remove any expired entries
-        trusted_certificates.retain(|_, cached_expiry| *cached_expiry >= now);
+        trusted_certs.retain(|_, cached_expiry| *cached_expiry >= now);
         // Write trusted certificate details to cache
-        trusted_certificates.insert(expected_input_data, expiry);
+        trusted_certs.insert(expected_input_data, expiry);
 
         Ok(())
     }
@@ -674,7 +701,7 @@ impl AttestedCertificateVerifier {
     fn bad_encoding(message: impl Into<String>) -> rustls::Error {
         let message = message.into();
         tracing::debug!("Rejecting malformed certificate or attestation payload: {message}");
-        rustls::Error::InvalidCertificate(rustls::CertificateError::BadEncoding)
+        InvalidCertificate(CertificateError::BadEncoding)
     }
 
     /// Helper to parse a certificate and map the error for rustls
@@ -707,18 +734,34 @@ impl ServerCertVerifier for AttestedCertificateVerifier {
         ocsp_response: &[u8],
         now: UnixTime,
     ) -> Result<ServerCertVerified, rustls::Error> {
-        if let Some(server_inner) = &self.server_verifier {
-            server_inner.verify_server_cert(
-                end_entity,
-                intermediates,
-                server_name,
-                ocsp_response,
-                now,
-            )?;
-        } else {
-            Self::verify_server_cert_constraints(end_entity, server_name, now)?;
+        let cert = Self::parse_x509_certificate(end_entity)?;
+
+        match self.server_verifier.verify_server_cert(
+            end_entity,
+            intermediates,
+            server_name,
+            ocsp_response,
+            now,
+        ) {
+            Err(InvalidCertificate(CertificateError::UnknownIssuer)) => {
+                if !self.accept_self_signed_certs || !intermediates.is_empty() {
+                    return Err(InvalidCertificate(CertificateError::UnknownIssuer));
+                }
+                verify_server_name(&ParsedCertificate::try_from(end_entity)?, server_name)?;
+                self.try_verifying_self_signed_cert(&cert, now)?;
+            }
+            Err(err) => return Err(err),
+            Ok(_) => {}
+        };
+
+        if let Some(ref allowed_leaf_cert_pubkeys) = self.allowed_leaf_cert_pubkeys &&
+            !allowed_leaf_cert_pubkeys.contains(&Sha512::digest(cert.public_key().raw).into())
+        {
+            tracing::warn!("Rejecting leaf certificate with un-allowed public key");
+            return Err(InvalidCertificate(CertificateError::UnknownIssuer));
         }
-        self.verify_attestation_binding(end_entity, now)?;
+
+        self.verify_attestation_binding(&cert, now)?;
         Ok(ServerCertVerified::assertion())
     }
 
@@ -755,23 +798,29 @@ impl ServerCertVerifier for AttestedCertificateVerifier {
     }
 
     fn root_hint_subjects(&self) -> Option<&[DistinguishedName]> {
-        self.server_verifier.as_ref().and_then(|server_inner| server_inner.root_hint_subjects())
+        self.server_verifier.root_hint_subjects()
     }
 }
 
 impl ClientCertVerifier for AttestedCertificateVerifier {
     fn offer_client_auth(&self) -> bool {
-        // We assume that if this certificate verifier is used for client auth,
-        // in [ServerConfig] then client auth is desired
+        // client must send its cert so that server could verify the attestation
+        // from the extension
         true
     }
 
     fn client_auth_mandatory(&self) -> bool {
+        // client must send its cert so that server could verify the attestation
+        // from the extension
         true
     }
 
     fn root_hint_subjects(&self) -> &[DistinguishedName] {
-        self.client_verifier.as_ref().map_or(&[], |client_inner| client_inner.root_hint_subjects())
+        if self.accept_self_signed_certs {
+            // allow client to elect self-signed cert for auth
+            return &[];
+        }
+        self.client_verifier.as_ref().root_hint_subjects()
     }
 
     fn verify_client_cert(
@@ -780,12 +829,27 @@ impl ClientCertVerifier for AttestedCertificateVerifier {
         intermediates: &[CertificateDer<'_>],
         now: UnixTime,
     ) -> Result<ClientCertVerified, rustls::Error> {
-        if let Some(client_inner) = &self.client_verifier {
-            client_inner.verify_client_cert(end_entity, intermediates, now)?;
-        } else {
-            Self::verify_cert_time_validity(end_entity, now)?;
+        let cert = Self::parse_x509_certificate(end_entity)?;
+
+        match self.client_verifier.verify_client_cert(end_entity, intermediates, now) {
+            Err(InvalidCertificate(CertificateError::UnknownIssuer)) => {
+                if !self.accept_self_signed_certs || !intermediates.is_empty() {
+                    return Err(InvalidCertificate(CertificateError::UnknownIssuer));
+                }
+                self.try_verifying_self_signed_cert(&cert, now)?;
+            }
+            Err(err) => return Err(err),
+            Ok(_) => {}
         }
-        self.verify_attestation_binding(end_entity, now)?;
+
+        if let Some(ref allowed_leaf_cert_pubkeys) = self.allowed_leaf_cert_pubkeys &&
+            !allowed_leaf_cert_pubkeys.contains(&Sha512::digest(cert.public_key().raw).into())
+        {
+            tracing::warn!("Rejecting leaf certificate with un-allowed public key");
+            return Err(InvalidCertificate(CertificateError::UnknownIssuer));
+        }
+
+        self.verify_attestation_binding(&cert, now)?;
         Ok(ClientCertVerified::assertion())
     }
 
@@ -827,54 +891,115 @@ pub struct AttestedCertificateVerifierBuilder {
     attestation_verifier: AttestationVerifier,
     /// Underlying cryptography provider
     crypto_provider: Option<Arc<CryptoProvider>>,
-    // Custom root of trust
+    /// Whether self-signed certificates should be accepted
+    accept_self_signed_certs: bool,
+    /// SHA512 hashes of ASN.1 DER representations of public keys allowed
+    /// for leaf certificates
+    ///
+    /// Note: `None` means default behaviour, that is any public key for
+    ///       leaf certificates is acceptable as long as the certificate
+    ///       and its embedded attestation are valid
+    allowed_leaf_cert_pubkeys: Option<Vec<[u8; 64]>>,
+    // Custom root-of-trust
     root_cert_store: Option<Arc<RootCertStore>>,
 }
 
 impl AttestedCertificateVerifierBuilder {
     /// Use specified crypto provider
-    pub fn with_crypto_provider(mut self, provider: Arc<CryptoProvider>) -> Self {
-        self.crypto_provider = Some(provider.clone());
+    pub fn with_crypto_provider(mut self, crypto_provider: Arc<CryptoProvider>) -> Self {
+        self.crypto_provider = Some(crypto_provider.clone());
         self
     }
 
-    /// Use specified root of trust
-    pub fn with_root_cert_store(mut self, root_store: RootCertStore) -> Self {
-        self.root_cert_store = Some(Arc::new(root_store));
+    /// Use specified root-of-trust
+    ///
+    /// Note: using this option disables self-signed certificates
+    pub fn with_root_cert_store(mut self, root_cert_store: RootCertStore) -> Self {
+        self.root_cert_store = Some(Arc::new(root_cert_store));
+        self.accept_self_signed_certs = false;
+        self
+    }
+
+    /// Allow specific public key for leaf certificates
+    ///
+    /// The input must be the DER-encoded public key bytes, such as
+    /// [`rcgen::KeyPair::public_key_der`]
+    ///
+    /// Note: if at least 1 public key is added to this allow-list of leaf
+    ///       certificate public keys, then only certificates with matching
+    ///       public keys will be accepted
+    pub fn with_allowed_leaf_cert_pubkey(mut self, pubkey_der: &[u8]) -> Self {
+        let mut allowed_leaf_cert_pubkeys = self.allowed_leaf_cert_pubkeys.unwrap_or_default();
+        allowed_leaf_cert_pubkeys.push(Sha512::digest(pubkey_der).into());
+        self.allowed_leaf_cert_pubkeys = Some(allowed_leaf_cert_pubkeys);
+        self
+    }
+
+    /// Allow multiple leaf certificate public keys
+    ///
+    /// The input should be a list of DER-encoded public key bytes, such as
+    /// `rcgen::KeyPair::public_key_der()`
+    ///
+    /// Note: if at least 1 public key is added to this allow-list of leaf
+    ///       certificate public keys, then only certificates with matching
+    ///       public keys will be accepted
+    pub fn with_allowed_leaf_cert_pubkeys<I, B>(mut self, pubkey_ders: I) -> Self
+    where
+        I: IntoIterator<Item = B>,
+        B: AsRef<[u8]>,
+    {
+        let mut allowed_self_signed_cert_pubkeys =
+            self.allowed_leaf_cert_pubkeys.unwrap_or_default();
+        allowed_self_signed_cert_pubkeys.extend(
+            pubkey_ders
+                .into_iter()
+                .map(|pubkey_der| -> [u8; 64] { Sha512::digest(pubkey_der.as_ref()).into() }),
+        );
+        self.allowed_leaf_cert_pubkeys = Some(allowed_self_signed_cert_pubkeys);
         self
     }
 
     /// Finish the build of AttestedCertificateVerifier
     pub fn finish(self) -> Result<AttestedCertificateVerifier, AttestedTlsError> {
-        let provider = match self.crypto_provider {
+        let crypto_provider = match self.crypto_provider {
             None => default_crypto_provider()?,
             Some(provider) => provider,
         };
 
-        let (server_inner, client_inner) = match self.root_cert_store {
-            Some(root_store) => {
-                let server_inner = WebPkiServerVerifier::builder_with_provider(
-                    root_store.clone(),
-                    provider.clone(),
-                )
-                .build()
-                .map_err(AttestedTlsError::VerifierBuilder)?;
-                let client_inner =
-                    WebPkiClientVerifier::builder_with_provider(root_store, provider.clone())
-                        .build()
-                        .map_err(AttestedTlsError::VerifierBuilder)?;
+        let server_verifier = WebPkiServerVerifier::builder_with_provider(
+            self.root_cert_store.clone().unwrap_or_else(|| {
+                Arc::new({
+                    let mut root_cert_store = rustls::RootCertStore::empty();
+                    root_cert_store.extend(webpki_roots::TLS_SERVER_ROOTS.to_owned());
+                    root_cert_store
+                })
+            }),
+            crypto_provider.clone(),
+        )
+        .build()
+        .map_err(AttestedTlsError::VerifierBuilder)?;
 
-                (Some(server_inner), Some(client_inner))
-            }
-            None => (None, None),
-        };
+        let client_verifier = WebPkiClientVerifier::builder_with_provider(
+            self.root_cert_store.clone().unwrap_or_else(|| {
+                Arc::new({
+                    let mut root_cert_store = rustls::RootCertStore::empty();
+                    root_cert_store.extend(webpki_roots::TLS_SERVER_ROOTS.to_owned());
+                    root_cert_store
+                })
+            }),
+            crypto_provider.clone(),
+        )
+        .build()
+        .map_err(AttestedTlsError::VerifierBuilder)?;
 
         Ok(AttestedCertificateVerifier {
-            server_verifier: server_inner,
-            client_verifier: client_inner,
-            crypto_provider: provider,
+            server_verifier,
+            client_verifier,
+            crypto_provider,
             attestation_verifier: self.attestation_verifier,
-            trusted_certificates: Default::default(),
+            trusted_certs: Default::default(),
+            accept_self_signed_certs: self.accept_self_signed_certs,
+            allowed_leaf_cert_pubkeys: self.allowed_leaf_cert_pubkeys.map(Arc::new),
         })
     }
 }
@@ -1040,10 +1165,7 @@ mod tests {
 
         let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
 
-        while client.is_handshaking() || server.is_handshaking() {
-            transfer_tls_client_to_server(&mut client, &mut server);
-            transfer_tls_server_to_client(&mut server, &mut client);
-        }
+        complete_handshake_with_timeout(&mut client, &mut server).await;
 
         assert!(!client.is_handshaking());
         assert!(!server.is_handshaking());
@@ -1102,10 +1224,7 @@ mod tests {
 
         let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
 
-        while client.is_handshaking() || server.is_handshaking() {
-            transfer_tls_client_to_server(&mut client, &mut server);
-            transfer_tls_server_to_client(&mut server, &mut client);
-        }
+        complete_handshake_with_timeout(&mut client, &mut server).await;
 
         assert!(!client.is_handshaking());
         assert!(!server.is_handshaking());
@@ -1189,10 +1308,7 @@ mod tests {
         .unwrap();
         let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
 
-        while client.is_handshaking() || server.is_handshaking() {
-            transfer_tls_client_to_server(&mut client, &mut server);
-            transfer_tls_server_to_client(&mut server, &mut client);
-        }
+        complete_handshake_with_timeout(&mut client, &mut server).await;
 
         assert!(!client.is_handshaking());
         assert!(!server.is_handshaking());
@@ -1240,10 +1356,7 @@ mod tests {
         .unwrap();
         let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
 
-        while client.is_handshaking() || server.is_handshaking() {
-            transfer_tls_client_to_server(&mut client, &mut server);
-            transfer_tls_server_to_client(&mut server, &mut client);
-        }
+        complete_handshake_with_timeout(&mut client, &mut server).await;
 
         assert!(!client.is_handshaking());
         assert!(!server.is_handshaking());
@@ -1287,7 +1400,7 @@ mod tests {
             UnixTime::now(),
         );
 
-        assert_eq!(result.unwrap_err(), Error::InvalidCertificate(CertificateError::BadEncoding));
+        assert_eq!(result.unwrap_err(), Error::InvalidCertificate(CertificateError::BadEncoding),);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1310,6 +1423,7 @@ mod tests {
         let verifier = AttestedCertificateVerifier::build(AttestationVerifier::mock())
             .with_crypto_provider(provider)
             .with_root_cert_store(roots)
+            .with_allowed_leaf_cert_pubkey(&[0u8; 32])
             .finish()
             .unwrap();
 
@@ -1343,6 +1457,7 @@ mod tests {
         let verifier = AttestedCertificateVerifier::build(AttestationVerifier::mock())
             .with_crypto_provider(provider)
             .with_root_cert_store(roots)
+            .with_allowed_leaf_cert_pubkey(&[0u8; 32])
             .finish()
             .unwrap();
 
@@ -1351,7 +1466,40 @@ mod tests {
         assert_eq!(result.unwrap_err(), Error::InvalidCertificate(CertificateError::UnknownIssuer));
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
+    async fn non_self_signed_attested_certificate_with_unknown_issuer_is_rejected() {
+        let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
+        let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let resolver = AttestedCertificateResolver::build(
+            "foo",
+            AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
+        )
+        .with_crypto_provider(provider.clone())
+        .with_key_pair(&key_pair)
+        .with_ca_cert(test_ca())
+        .with_certificate_validity(Duration::from_secs(4))
+        .finish()
+        .unwrap();
+        let verifier = AttestedCertificateVerifier::build(AttestationVerifier::mock())
+            .with_crypto_provider(provider)
+            .finish()
+            .unwrap();
+        let cert = resolver.state.certificate.read().unwrap().first().unwrap().clone();
+        let parsed_cert = AttestedCertificateVerifier::parse_x509_certificate(&cert).unwrap();
+
+        assert_ne!(parsed_cert.subject(), parsed_cert.issuer());
+
+        let result = verify_server_cert_direct(
+            &verifier,
+            &cert,
+            &ServerName::try_from("foo").unwrap(),
+            UnixTime::now(),
+        );
+
+        assert_eq!(result.unwrap_err(), Error::InvalidCertificate(CertificateError::UnknownIssuer));
+    }
+
+    #[tokio::test]
     async fn self_signed_attested_certificate_with_wrong_name_is_rejected() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
@@ -1380,7 +1528,67 @@ mod tests {
         assert!(matches!(
             result.unwrap_err(),
             Error::InvalidCertificate(CertificateError::NotValidForNameContext { .. })
-        ));
+        ),);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn self_signed_attested_certificate_with_allowed_pubkey_is_accepted() {
+        let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
+        let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let resolver = AttestedCertificateResolver::build(
+            "foo",
+            AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
+        )
+        .with_crypto_provider(provider.clone())
+        .with_key_pair(&key_pair)
+        .with_certificate_validity(Duration::from_secs(4))
+        .finish()
+        .unwrap();
+        let verifier = AttestedCertificateVerifier::build(AttestationVerifier::mock())
+            .with_crypto_provider(provider)
+            .with_allowed_leaf_cert_pubkey(&key_pair.public_key_der())
+            .finish()
+            .unwrap();
+        let cert = resolver.state.certificate.read().unwrap().first().unwrap().clone();
+
+        verify_server_cert_direct(
+            &verifier,
+            &cert,
+            &ServerName::try_from("foo").unwrap(),
+            UnixTime::now(),
+        )
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn self_signed_attested_certificate_with_not_allowed_pubkey_is_rejected() {
+        let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
+        let trusted_key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let presented_key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let resolver = AttestedCertificateResolver::build(
+            "foo",
+            AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
+        )
+        .with_crypto_provider(provider.clone())
+        .with_key_pair(&presented_key_pair)
+        .with_certificate_validity(Duration::from_secs(4))
+        .finish()
+        .unwrap();
+        let verifier = AttestedCertificateVerifier::build(AttestationVerifier::mock())
+            .with_crypto_provider(provider)
+            .with_allowed_leaf_cert_pubkey(&trusted_key_pair.public_key_der())
+            .finish()
+            .unwrap();
+        let cert = resolver.state.certificate.read().unwrap().first().unwrap().clone();
+
+        let result = verify_server_cert_direct(
+            &verifier,
+            &cert,
+            &ServerName::try_from("foo").unwrap(),
+            UnixTime::now(),
+        );
+
+        assert_eq!(result.unwrap_err(), Error::InvalidCertificate(CertificateError::UnknownIssuer));
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1396,13 +1604,14 @@ mod tests {
         .with_certificate_validity(Duration::from_secs(4))
         .finish()
         .unwrap();
-        let original_cert = resolver.state.certificate.read().unwrap().first().unwrap().clone();
+
+        let cert = resolver.state.certificate.read().unwrap();
+        let cert =
+            AttestedCertificateVerifier::parse_x509_certificate(cert.first().unwrap()).unwrap();
         let (original_report_data, original_not_after) =
-            AttestedCertificateVerifier::cert_binding_data(&original_cert).unwrap();
-        let parsed_cert =
-            AttestedCertificateVerifier::parse_x509_certificate(&original_cert).unwrap();
-        let not_before = parsed_cert.validity().not_before.timestamp() as u64;
-        let not_after = parsed_cert.validity().not_after.timestamp() as u64;
+            AttestedCertificateVerifier::cert_binding_data(&cert).unwrap();
+        let not_before = cert.validity().not_before.timestamp() as u64;
+        let not_after = cert.validity().not_after.timestamp() as u64;
         let key_pair = KeyPair::try_from(resolver.state.key_pair_der.clone()).unwrap();
         let replay_name = "bar".to_string();
         let replay_alt_names = vec![replay_name.clone()];
@@ -1415,8 +1624,9 @@ mod tests {
             .usage_server_auth(true)
             .usage_client_auth(true)
             .build();
-        let replayed_cert: CertificateDer<'static> =
-            replayed_cert_request.self_signed().unwrap().der().to_vec().into();
+        let replayed_cert = replayed_cert_request.self_signed().unwrap();
+        let replayed_cert =
+            AttestedCertificateVerifier::parse_x509_certificate(replayed_cert.der()).unwrap();
         let (replayed_report_data, replayed_not_after) =
             AttestedCertificateVerifier::cert_binding_data(&replayed_cert).unwrap();
 
@@ -1474,8 +1684,11 @@ mod tests {
             .finish()
             .unwrap();
         let cert = resolver.state.certificate.read().unwrap().first().unwrap().clone();
-        let (expected_input_data, not_after) =
-            AttestedCertificateVerifier::cert_binding_data(&cert).unwrap();
+
+        let (expected_input_data, not_after) = AttestedCertificateVerifier::cert_binding_data(
+            &AttestedCertificateVerifier::parse_x509_certificate(&cert).unwrap(),
+        )
+        .unwrap();
 
         verify_server_cert_direct(
             &verifier,
@@ -1485,7 +1698,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            verifier.trusted_certificates.read().unwrap().get(&expected_input_data),
+            verifier.trusted_certs.read().unwrap().get(&expected_input_data),
             Some(&not_after)
         );
 
@@ -1515,6 +1728,22 @@ mod tests {
         let key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
         let params = CertificateParams::new(vec![subject_name.to_string()]).unwrap();
         params.self_signed(&key).unwrap().der().to_vec().into()
+    }
+
+    async fn complete_handshake_with_timeout(
+        client: &mut ClientConnection,
+        server: &mut ServerConnection,
+    ) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while client.is_handshaking() || server.is_handshaking() {
+                transfer_tls_client_to_server(client, server);
+                transfer_tls_server_to_client(server, client);
+
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("TLS handshake timed out");
     }
 
     fn transfer_tls_client_to_server(client: &mut ClientConnection, server: &mut ServerConnection) {

--- a/crates/attested-tls/src/lib.rs
+++ b/crates/attested-tls/src/lib.rs
@@ -1084,7 +1084,7 @@ mod tests {
         )
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn certificate_resolver_creates_initial_certificate() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
@@ -1103,7 +1103,7 @@ mod tests {
         assert_eq!(certificate.len(), 1);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn certificate_resolver_rejects_too_short_validity_duration() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
@@ -1120,7 +1120,7 @@ mod tests {
         assert!(matches!(error, AttestedTlsError::InvalidCertificateValidityDuration { .. }));
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn server_and_client_configs_complete_a_handshake() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let server_name = "foo";
@@ -1166,7 +1166,7 @@ mod tests {
         assert!(!server.is_handshaking());
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn ca_signed_server_and_client_configs_complete_a_handshake() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
@@ -1225,7 +1225,7 @@ mod tests {
         assert!(!server.is_handshaking());
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn certificate_is_renewed_before_expiry() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
@@ -1249,7 +1249,7 @@ mod tests {
         assert_ne!(initial_certificate.as_ref(), renewed_certificate.as_ref());
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn server_and_client_configs_complete_a_mutual_auth_handshake() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
@@ -1311,7 +1311,7 @@ mod tests {
         assert!(server.peer_certificates().is_some());
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn alternate_san_completes_a_handshake() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
@@ -1357,7 +1357,7 @@ mod tests {
         assert!(!server.is_handshaking());
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn malformed_certificate_returns_bad_encoding() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let verifier = AttestedCertificateVerifier::build(AttestationVerifier::mock())
@@ -1376,7 +1376,7 @@ mod tests {
         assert_eq!(result.unwrap_err(), Error::InvalidCertificate(CertificateError::BadEncoding));
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn certificate_without_attestation_extension_returns_bad_encoding() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let cert = plain_self_signed_certificate("foo");
@@ -1398,7 +1398,7 @@ mod tests {
         assert_eq!(result.unwrap_err(), Error::InvalidCertificate(CertificateError::BadEncoding),);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn private_ca_verifier_rejects_untrusted_self_signed_attested_server_cert() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let ca = test_ca();
@@ -1432,7 +1432,7 @@ mod tests {
         assert_eq!(result.unwrap_err(), Error::InvalidCertificate(CertificateError::UnknownIssuer));
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn private_ca_verifier_rejects_untrusted_self_signed_attested_client_cert() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let ca = test_ca();
@@ -1526,7 +1526,7 @@ mod tests {
         ),);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn self_signed_attested_certificate_with_allowed_pubkey_is_accepted() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
@@ -1555,7 +1555,7 @@ mod tests {
         .unwrap();
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn self_signed_attested_certificate_with_not_allowed_pubkey_is_rejected() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let trusted_key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
@@ -1586,7 +1586,7 @@ mod tests {
         assert_eq!(result.unwrap_err(), Error::InvalidCertificate(CertificateError::UnknownIssuer));
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn certificate_binding_changes_when_identity_changes() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
@@ -1629,7 +1629,7 @@ mod tests {
         assert_ne!(original_report_data, replayed_report_data);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn attestation_rejection_returns_application_verification_failure() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
@@ -1661,7 +1661,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn verifier_reuses_trusted_certificate_cache() {
         let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();

--- a/crates/attested-tls/src/lib.rs
+++ b/crates/attested-tls/src/lib.rs
@@ -514,7 +514,7 @@ impl AttestedCertificateVerifier {
         })
     }
 
-    /// Create a TLS certificate verifier wrapping given attestation
+    /// Create a TLS certificate verifier builder wrapping given attestation
     /// verifier
     pub fn build(attestation_verifier: AttestationVerifier) -> AttestedCertificateVerifierBuilder {
         AttestedCertificateVerifierBuilder {

--- a/crates/attested-tls/tests/nested_tls.rs
+++ b/crates/attested-tls/tests/nested_tls.rs
@@ -18,7 +18,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt, duplex};
 async fn nested_tls_uses_attested_tls_for_inner_session() {
     let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
     let (outer_server, outer_client) = plain_tls_config_pair(provider.clone());
-    let inner_server = attested_server_config("localhost", provider.clone()).await;
+    let inner_server = attested_server_config("localhost", provider.clone());
     let inner_client = attested_client_config(provider.clone());
 
     let acceptor = NestingTlsAcceptor::new(Arc::new(outer_server), Arc::new(inner_server));
@@ -83,7 +83,7 @@ fn plain_tls_config_pair(provider: Arc<CryptoProvider>) -> (ServerConfig, Client
 
 /// Create attested server TLS config with mock DCAP attestation and
 /// self-signed certs
-async fn attested_server_config(server_name: &str, provider: Arc<CryptoProvider>) -> ServerConfig {
+fn attested_server_config(server_name: &str, provider: Arc<CryptoProvider>) -> ServerConfig {
     let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
     let resolver = AttestedCertificateResolver::new_with_provider(
         AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
@@ -94,7 +94,6 @@ async fn attested_server_config(server_name: &str, provider: Arc<CryptoProvider>
         provider.clone(),
         std::time::Duration::from_secs(91),
     )
-    .await
     .unwrap();
 
     ServerConfig::builder_with_provider(provider)

--- a/crates/attested-tls/tests/nested_tls.rs
+++ b/crates/attested-tls/tests/nested_tls.rs
@@ -85,15 +85,13 @@ fn plain_tls_config_pair(provider: Arc<CryptoProvider>) -> (ServerConfig, Client
 /// self-signed certs
 fn attested_server_config(server_name: &str, provider: Arc<CryptoProvider>) -> ServerConfig {
     let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
-    let resolver = AttestedCertificateResolver::new_with_provider(
+    let resolver = AttestedCertificateResolver::build(
+        server_name,
         AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
-        &key_pair,
-        None,
-        server_name.to_string(),
-        vec![],
-        provider.clone(),
-        std::time::Duration::from_secs(91),
     )
+    .with_crypto_provider(provider.clone())
+    .with_key_pair(&key_pair)
+    .finish()
     .unwrap();
 
     ServerConfig::builder_with_provider(provider)
@@ -105,12 +103,10 @@ fn attested_server_config(server_name: &str, provider: Arc<CryptoProvider>) -> S
 
 /// Create client TLS config with attestation verification
 fn attested_client_config(provider: Arc<CryptoProvider>) -> ClientConfig {
-    let verifier = AttestedCertificateVerifier::new_with_provider(
-        None,
-        AttestationVerifier::mock(),
-        provider.clone(),
-    )
-    .unwrap();
+    let verifier = AttestedCertificateVerifier::build(AttestationVerifier::mock())
+        .with_crypto_provider(provider.clone())
+        .finish()
+        .unwrap();
 
     ClientConfig::builder_with_provider(provider)
         .with_safe_default_protocol_versions()

--- a/crates/attested-tls/tests/nested_tls.rs
+++ b/crates/attested-tls/tests/nested_tls.rs
@@ -84,8 +84,10 @@ fn plain_tls_config_pair(provider: Arc<CryptoProvider>) -> (ServerConfig, Client
 /// Create attested server TLS config with mock DCAP attestation and
 /// self-signed certs
 async fn attested_server_config(server_name: &str, provider: Arc<CryptoProvider>) -> ServerConfig {
+    let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
     let resolver = AttestedCertificateResolver::new_with_provider(
         AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
+        &key_pair,
         None,
         server_name.to_string(),
         vec![],


### PR DESCRIPTION
this PR:

- makes `detect()` functions (that auto-determine platform) and `AttestedCertificateResolver::new()` non-async so that they could be used outside tokio
- implements builder pattern for cert resolver/verifier
- implements pubkey allow-lists for self-signed certs
- switches to non-async  `verify_attestation_sync()` in the context of blocking `verify_attestation_binding()`
- renames `primary_name` to `subject` in the context of TLS cert related functions
- enables using pre-determined key-pairs for attestation certs
- re-exports `rcgen` to avoid version collisions when the downstream needs to access `rcgen`
- other minor fixes