### PR TITLE
attested-tls should use the new sync verifier method rather than the async one with block_in_place

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "attestation",
+ "mock-tdx",
  "nested-tls",
  "ra-tls",
  "rcgen 0.14.7",

--- a/crates/attestation/src/dcap.rs
+++ b/crates/attestation/src/dcap.rs
@@ -236,10 +236,16 @@ pub async fn verify_dcap_attestation(
 pub fn verify_dcap_attestation_sync(
     input: Vec<u8>,
     expected_input_data: [u8; 64],
-    _pccs: Pccs,
+    pccs: Pccs,
 ) -> Result<MultiMeasurements, DcapVerificationError> {
-    // In tests we use mock quotes which will fail to verify
     let quote = Quote::parse(&input)?;
+    let ca = quote.ca()?;
+    let fmspc = hex::encode_upper(quote.fmspc()?);
+    let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)?.as_secs();
+    let collateral = pccs.get_collateral_sync(fmspc, ca, now)?;
+    let verifier = mock_tdx::mock_dcap_verifier();
+    verifier.verify(&input, &collateral, now)?;
+
     let measurements = MultiMeasurements::from_dcap_qvl_quote(&quote)?;
     if get_quote_input_data(quote.report.clone()) != expected_input_data {
         return Err(DcapVerificationError::InputMismatch);
@@ -396,7 +402,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_mock_dcap_verify_uses_pccs_when_provided() {
-        let mock_pcs = spawn_mock_pcs_server(MockPcsConfig::default()).await.unwrap();
+        let mock_pcs = spawn_mock_pcs_server(MockPcsConfig {
+            include_fmspcs_listing: false,
+            ..MockPcsConfig::default()
+        })
+        .await
+        .unwrap();
         let pccs = Pccs::new(Some(mock_pcs.base_url.clone()));
         let expected_input_data = [0xA5; 64];
         let attestation_bytes = create_dcap_attestation(expected_input_data).unwrap();

--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -321,6 +321,18 @@ impl AttestationVerifier {
         }
     }
 
+    /// Expect mock measurements used in tests, and use a PCCS
+    #[cfg(any(test, feature = "mock"))]
+    pub fn mock_with_pccs(pccs_url: String) -> Self {
+        Self {
+            measurement_policy: MeasurementPolicy::mock(),
+            pccs_url: None,
+            dump_dcap_quotes: false,
+            override_azure_outdated_tcb: false,
+            internal_pccs: Some(Pccs::new(Some(pccs_url))),
+        }
+    }
+
     /// Resolves once the internal PCCS cache is ready to verify
     /// attestations
     ///
@@ -597,6 +609,7 @@ pub enum AttestationError {
 
 #[cfg(test)]
 mod tests {
+    use mock_tdx::mock_pcs::{MockPcsConfig, spawn_mock_pcs_server};
     use tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
         net::TcpListener,
@@ -673,11 +686,17 @@ mod tests {
         assert_eq!(wrapped.attestation, vec![9, 8]);
     }
 
-    #[test]
-    fn mock_verifier_supports_sync_verification() {
+    #[tokio::test]
+    async fn mock_verifier_supports_sync_verification() {
         let input_data = [7u8; 64];
         let attestation = dcap::create_dcap_attestation(input_data).unwrap();
-        let verifier = AttestationVerifier::mock();
+
+        let mock_pcs_server = spawn_mock_pcs_server(MockPcsConfig::default()).await.unwrap();
+
+        let verifier = AttestationVerifier::mock_with_pccs(mock_pcs_server.base_url.clone());
+        if let Some(ref pccs) = verifier.internal_pccs {
+            pccs.ready().await.unwrap();
+        }
 
         let result = verifier.verify_attestation_sync(
             AttestationExchangeMessage { attestation_type: AttestationType::DcapTdx, attestation },

--- a/crates/attested-tls/Cargo.toml
+++ b/crates/attested-tls/Cargo.toml
@@ -19,6 +19,7 @@ yasna = "0.5.2"
 
 [dev-dependencies]
 attestation = { workspace = true, features = ["mock"] }
+mock-tdx = { workspace = true }
 nested-tls = { path = "../nested-tls" }
 rustls = { workspace = true, default-features = false, features = ["aws_lc_rs"] }
 

--- a/crates/attested-tls/Cargo.toml
+++ b/crates/attested-tls/Cargo.toml
@@ -22,8 +22,9 @@ yasna = "0.5.2"
 [dev-dependencies]
 attestation = { workspace = true, features = ["mock"] }
 mock-tdx = { workspace = true }
-nested-tls = { path = "../nested-tls" }
 rustls = { workspace = true, default-features = false, features = ["aws_lc_rs"] }
+
+nested-tls = { path = "../nested-tls" }
 
 [lints]
 workspace = true

--- a/crates/attested-tls/src/lib.rs
+++ b/crates/attested-tls/src/lib.rs
@@ -602,21 +602,16 @@ impl AttestedCertificateVerifier {
 
         let attestation = Self::extract_custom_attestation_from_cert(end_entity)?;
 
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                self.attestation_verifier
-                    .verify_attestation(attestation, expected_input_data)
-                    .await
-                    .map_err(|err| {
-                        tracing::warn!(
-                            "Rejecting certificate after attestation verification failure: {err}"
-                        );
-                        rustls::Error::InvalidCertificate(
-                            rustls::CertificateError::ApplicationVerificationFailure,
-                        )
-                    })
-            })
-        })?;
+        self.attestation_verifier
+            .verify_attestation_sync(attestation, expected_input_data)
+            .map_err(|err| {
+                tracing::warn!(
+                    "Rejecting certificate after attestation verification failure: {err}"
+                );
+                rustls::Error::InvalidCertificate(
+                    rustls::CertificateError::ApplicationVerificationFailure,
+                )
+            })?;
 
         let mut trusted_certificates = self.trusted_certificates.write().map_err(|_| {
             rustls::Error::General("Trusted certificate cache lock poisoned".into())
@@ -814,6 +809,7 @@ pub enum AttestedTlsError {
 mod tests {
     use std::{io::Cursor, sync::Arc};
 
+    use mock_tdx::mock_pcs::{MockPcsConfig, spawn_mock_pcs_server};
     use ra_tls::rcgen::{BasicConstraints, CertificateParams, IsCa};
     use rustls::{
         CertificateError,
@@ -857,6 +853,19 @@ mod tests {
             &[],
             now,
         )
+    }
+
+    async fn ready_mock_attested_verifier(
+        root_store: Option<RootCertStore>,
+        provider: Arc<CryptoProvider>,
+    ) -> AttestedCertificateVerifier {
+        let mock_pcs_server = spawn_mock_pcs_server(MockPcsConfig::default()).await.unwrap();
+        let verifier = AttestationVerifier::mock_with_pccs(mock_pcs_server.base_url.clone());
+        if let Some(ref pccs) = verifier.internal_pccs {
+            pccs.ready().await.unwrap();
+        }
+
+        AttestedCertificateVerifier::new_with_provider(root_store, verifier, provider).unwrap()
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -910,12 +919,7 @@ mod tests {
         .await
         .unwrap();
 
-        let verifier = AttestedCertificateVerifier::new_with_provider(
-            None,
-            AttestationVerifier::mock(),
-            provider.clone(),
-        )
-        .unwrap();
+        let verifier = ready_mock_attested_verifier(None, provider.clone()).await;
 
         let server_config = ServerConfig::builder_with_provider(provider.clone())
             .with_safe_default_protocol_versions()
@@ -971,12 +975,7 @@ mod tests {
         let mut roots = RootCertStore::empty();
         roots.add(ca_cert).unwrap();
 
-        let verifier = AttestedCertificateVerifier::new_with_provider(
-            Some(roots),
-            AttestationVerifier::mock(),
-            provider.clone(),
-        )
-        .unwrap();
+        let verifier = ready_mock_attested_verifier(Some(roots), provider.clone()).await;
 
         let server_config = ServerConfig::builder_with_provider(provider.clone())
             .with_safe_default_protocol_versions()
@@ -1059,18 +1058,8 @@ mod tests {
         .await
         .unwrap();
 
-        let server_verifier = AttestedCertificateVerifier::new_with_provider(
-            None,
-            AttestationVerifier::mock(),
-            provider.clone(),
-        )
-        .unwrap();
-        let client_verifier = AttestedCertificateVerifier::new_with_provider(
-            None,
-            AttestationVerifier::mock(),
-            provider.clone(),
-        )
-        .unwrap();
+        let server_verifier = ready_mock_attested_verifier(None, provider.clone()).await;
+        let client_verifier = ready_mock_attested_verifier(None, provider.clone()).await;
 
         let server_config = ServerConfig::builder_with_provider(provider.clone())
             .with_safe_default_protocol_versions()
@@ -1117,12 +1106,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let verifier = AttestedCertificateVerifier::new_with_provider(
-            None,
-            AttestationVerifier::mock(),
-            provider.clone(),
-        )
-        .unwrap();
+        let verifier = ready_mock_attested_verifier(None, provider.clone()).await;
 
         let server_config = ServerConfig::builder_with_provider(provider.clone())
             .with_safe_default_protocol_versions()
@@ -1385,12 +1369,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let mut verifier = AttestedCertificateVerifier::new_with_provider(
-            None,
-            AttestationVerifier::mock(),
-            provider,
-        )
-        .unwrap();
+        let mut verifier = ready_mock_attested_verifier(None, provider).await;
         let cert = resolver.state.certificate.read().unwrap().first().unwrap().clone();
         let (expected_input_data, not_after) =
             AttestedCertificateVerifier::cert_binding_data(&cert).unwrap();

--- a/crates/attested-tls/src/lib.rs
+++ b/crates/attested-tls/src/lib.rs
@@ -1397,6 +1397,78 @@ mod tests {
         .unwrap();
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sync_verifier_cache_miss_fails_then_succeeds_after_background_fetch() {
+        let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
+        let resolver = AttestedCertificateResolver::new_with_provider(
+            AttestationGenerator::new(AttestationType::DcapTdx, None).unwrap(),
+            None,
+            "foo".to_string(),
+            vec![],
+            provider.clone(),
+            Duration::from_secs(4),
+        )
+        .await
+        .unwrap();
+        let cert = resolver.state.certificate.read().unwrap().first().unwrap().clone();
+
+        // Mock PCS is set up to not list the FMSPCs, meaning the pre-warm
+        // wont fetch anything
+        let mock_pcs = spawn_mock_pcs_server(MockPcsConfig {
+            include_fmspcs_listing: false,
+            ..MockPcsConfig::default()
+        })
+        .await
+        .unwrap();
+
+        let verifier = AttestedCertificateVerifier::new_with_provider(
+            None,
+            AttestationVerifier::mock_with_pccs(mock_pcs.base_url.clone()),
+            provider,
+        )
+        .unwrap();
+
+        let first_result = verify_server_cert_direct(
+            &verifier,
+            &cert,
+            &ServerName::try_from("foo").unwrap(),
+            UnixTime::now(),
+        );
+
+        // Initially verification fails because the PCCS doesn't have the
+        // collateral associated with the quote
+        assert_eq!(
+            first_result.unwrap_err(),
+            Error::InvalidCertificate(CertificateError::ApplicationVerificationFailure)
+        );
+
+        // Now we wait a moment for the PCCS to fetch it in the background
+        for _ in 0..50 {
+            if verify_server_cert_direct(
+                &verifier,
+                &cert,
+                &ServerName::try_from("foo").unwrap(),
+                UnixTime::now(),
+            )
+            .is_ok()
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // Now verification succeeds
+        verify_server_cert_direct(
+            &verifier,
+            &cert,
+            &ServerName::try_from("foo").unwrap(),
+            UnixTime::now(),
+        )
+        .unwrap();
+        assert_eq!(mock_pcs.tcb_call_count(), 1);
+        assert_eq!(mock_pcs.qe_call_count(), 1);
+    }
+
     /// Helper to create a private certificate authority
     fn test_ca() -> CaCert {
         let key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();

--- a/crates/attested-tls/tests/nested_tls.rs
+++ b/crates/attested-tls/tests/nested_tls.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use attestation::{AttestationGenerator, AttestationType, AttestationVerifier};
 use attested_tls::{AttestedCertificateResolver, AttestedCertificateVerifier};
+use mock_tdx::mock_pcs::{MockPcsConfig, spawn_mock_pcs_server};
 use nested_tls::{client::NestingTlsConnector, server::NestingTlsAcceptor};
 use ra_tls::rcgen::{KeyPair, PKCS_ECDSA_P256_SHA256};
 use rustls::{
@@ -19,7 +20,7 @@ async fn nested_tls_uses_attested_tls_for_inner_session() {
     let provider: Arc<CryptoProvider> = aws_lc_rs::default_provider().into();
     let (outer_server, outer_client) = plain_tls_config_pair(provider.clone());
     let inner_server = attested_server_config("localhost", provider.clone()).await;
-    let inner_client = attested_client_config(provider.clone());
+    let inner_client = attested_client_config(provider.clone()).await;
 
     let acceptor = NestingTlsAcceptor::new(Arc::new(outer_server), Arc::new(inner_server));
     let connector = NestingTlsConnector::new(Arc::new(outer_client), Arc::new(inner_client));
@@ -103,13 +104,14 @@ async fn attested_server_config(server_name: &str, provider: Arc<CryptoProvider>
 }
 
 /// Create client TLS config with attestation verification
-fn attested_client_config(provider: Arc<CryptoProvider>) -> ClientConfig {
-    let verifier = AttestedCertificateVerifier::new_with_provider(
-        None,
-        AttestationVerifier::mock(),
-        provider.clone(),
-    )
-    .unwrap();
+async fn attested_client_config(provider: Arc<CryptoProvider>) -> ClientConfig {
+    let mock_pcs_server = spawn_mock_pcs_server(MockPcsConfig::default()).await.unwrap();
+    let verifier = AttestationVerifier::mock_with_pccs(mock_pcs_server.base_url.clone());
+    if let Some(ref pccs) = verifier.internal_pccs {
+        pccs.ready().await.unwrap();
+    }
+    let verifier =
+        AttestedCertificateVerifier::new_with_provider(None, verifier, provider.clone()).unwrap();
 
     ClientConfig::builder_with_provider(provider)
         .with_safe_default_protocol_versions()

--- a/crates/mock-tdx/src/lib.rs
+++ b/crates/mock-tdx/src/lib.rs
@@ -1,4 +1,4 @@
-mod mock_pcs;
+pub mod mock_pcs;
 
 use dcap_qvl::{
     QuoteCollateralV3,

--- a/crates/mock-tdx/src/mock_pcs.rs
+++ b/crates/mock-tdx/src/mock_pcs.rs
@@ -43,7 +43,7 @@ impl Default for MockPcsConfig {
         let qe_identity: Value = serde_json::from_str(&collateral.qe_identity).unwrap();
 
         Self {
-            include_fmspcs_listing: false,
+            include_fmspcs_listing: true,
             tcb_next_update: tcb_info["nextUpdate"].as_str().unwrap().to_string(),
             qe_next_update: qe_identity["nextUpdate"].as_str().unwrap().to_string(),
             refreshed_tcb_next_update: None,


### PR DESCRIPTION
This switches attested-tls certificate verification to use the synchronous attestation verifier rather than using `tokio::block_in_place` to run the async version.

It includes a test which demonstrates that when certification verification fails due to missing collateral in the PCCS, we can wait a moment and re-try, as the PCCS will immediately fetch the missing collateral when this happens. The unmerged 'mock-pck' crate is needed for that, so this PR targets https://github.com/flashbots/attested-tls/pull/29

Edit:  This is actually now already done in https://github.com/flashbots/attested-tls/pull/20 but i think its still worth merging this to have a test covering it.