### PR TITLE
Attested certificate verifier should require client authentication

### DIFF
--- a/crates/attested-tls/src/lib.rs
+++ b/crates/attested-tls/src/lib.rs
@@ -721,11 +721,13 @@ impl ServerCertVerifier for AttestedCertificateVerifier {
 
 impl ClientCertVerifier for AttestedCertificateVerifier {
     fn offer_client_auth(&self) -> bool {
-        self.client_inner.as_ref().is_none_or(|client_inner| client_inner.offer_client_auth())
+        // We assume that if this certificate verifier is used for client auth,
+        // in [ServerConfig] then client auth is desired
+        true
     }
 
     fn client_auth_mandatory(&self) -> bool {
-        self.client_inner.as_ref().is_none_or(|client_inner| client_inner.client_auth_mandatory())
+        true
     }
 
     fn root_hint_subjects(&self) -> &[DistinguishedName] {


### PR DESCRIPTION
When an AttestedClientVerifier is used in a rustls ServerConfig for client authentication, this means the server wants the client to authenticate.

This PR makes it so that the trait methods relevant to requiring client authentication unconditionally return true, to require clients to authenticate.  