### PR TITLE
Bump ra-tls to 07d2cf6 and update attested-tls for new API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,8 +734,8 @@ dependencies = [
 
 [[package]]
 name = "cc-eventlog"
-version = "0.5.8"
-source = "git+https://github.com/Dstack-TEE/dstack.git?rev=4f602dddc0542cd34da031c90ac0b3a560f316ed#4f602dddc0542cd34da031c90ac0b3a560f316ed"
+version = "0.5.11"
+source = "git+https://github.com/Dstack-TEE/dstack.git?rev=07d2cf6bd376a3c56f855aa47c8de003bb427e48#07d2cf6bd376a3c56f855aa47c8de003bb427e48"
 dependencies = [
  "anyhow",
  "digest",
@@ -1334,8 +1334,8 @@ dependencies = [
 
 [[package]]
 name = "dstack-attest"
-version = "0.5.8"
-source = "git+https://github.com/Dstack-TEE/dstack.git?rev=4f602dddc0542cd34da031c90ac0b3a560f316ed#4f602dddc0542cd34da031c90ac0b3a560f316ed"
+version = "0.5.11"
+source = "git+https://github.com/Dstack-TEE/dstack.git?rev=07d2cf6bd376a3c56f855aa47c8de003bb427e48#07d2cf6bd376a3c56f855aa47c8de003bb427e48"
 dependencies = [
  "anyhow",
  "cc-eventlog",
@@ -1349,6 +1349,7 @@ dependencies = [
  "insta",
  "or-panic",
  "parity-scale-codec",
+ "rmp-serde",
  "serde",
  "serde-human-bytes",
  "serde_json",
@@ -1360,8 +1361,8 @@ dependencies = [
 
 [[package]]
 name = "dstack-types"
-version = "0.5.8"
-source = "git+https://github.com/Dstack-TEE/dstack.git?rev=4f602dddc0542cd34da031c90ac0b3a560f316ed#4f602dddc0542cd34da031c90ac0b3a560f316ed"
+version = "0.5.11"
+source = "git+https://github.com/Dstack-TEE/dstack.git?rev=07d2cf6bd376a3c56f855aa47c8de003bb427e48#07d2cf6bd376a3c56f855aa47c8de003bb427e48"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -3118,8 +3119,8 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ra-tls"
-version = "0.5.8"
-source = "git+https://github.com/Dstack-TEE/dstack.git?rev=4f602dddc0542cd34da031c90ac0b3a560f316ed#4f602dddc0542cd34da031c90ac0b3a560f316ed"
+version = "0.5.11"
+source = "git+https://github.com/Dstack-TEE/dstack.git?rev=07d2cf6bd376a3c56f855aa47c8de003bb427e48#07d2cf6bd376a3c56f855aa47c8de003bb427e48"
 dependencies = [
  "anyhow",
  "bon",
@@ -3821,8 +3822,8 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "size-parser"
-version = "0.5.8"
-source = "git+https://github.com/Dstack-TEE/dstack.git?rev=4f602dddc0542cd34da031c90ac0b3a560f316ed#4f602dddc0542cd34da031c90ac0b3a560f316ed"
+version = "0.5.11"
+source = "git+https://github.com/Dstack-TEE/dstack.git?rev=07d2cf6bd376a3c56f855aa47c8de003bb427e48#07d2cf6bd376a3c56f855aa47c8de003bb427e48"
 dependencies = [
  "anyhow",
  "serde",
@@ -3952,8 +3953,8 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tdx-attest"
-version = "0.5.8"
-source = "git+https://github.com/Dstack-TEE/dstack.git?rev=4f602dddc0542cd34da031c90ac0b3a560f316ed#4f602dddc0542cd34da031c90ac0b3a560f316ed"
+version = "0.5.11"
+source = "git+https://github.com/Dstack-TEE/dstack.git?rev=07d2cf6bd376a3c56f855aa47c8de003bb427e48#07d2cf6bd376a3c56f855aa47c8de003bb427e48"
 dependencies = [
  "anyhow",
  "cc-eventlog",

--- a/crates/attested-tls/Cargo.toml
+++ b/crates/attested-tls/Cargo.toml
@@ -9,7 +9,7 @@ rustls = { workspace = true, default-features = false }
 tokio = { workspace = true }
 
 anyhow = "1.0.102"
-ra-tls = { git = "https://github.com/Dstack-TEE/dstack.git", rev = "4f602dddc0542cd34da031c90ac0b3a560f316ed", features = ["quote"] }
+ra-tls = { git = "https://github.com/Dstack-TEE/dstack.git", rev = "07d2cf6bd376a3c56f855aa47c8de003bb427e48", features = ["quote"] }
 rcgen = "0.14.7"
 serde_json = "1.0.149"
 sha2 = "0.10.9"

--- a/crates/attested-tls/src/lib.rs
+++ b/crates/attested-tls/src/lib.rs
@@ -530,7 +530,8 @@ impl AttestedCertificateVerifier {
     pub fn extract_custom_attestation_from_cert(
         cert: &X509Certificate<'_>,
     ) -> Result<AttestationExchangeMessage, rustls::Error> {
-        if let Ok(Some(attestation)) = ra_tls::attestation::from_cert(cert) &&
+        if let Ok(Some(VersionedAttestation::V0 { attestation })) =
+            ra_tls::attestation::from_cert(cert) &&
             let AttestationQuote::DstackTdx(tdx_quote) = attestation.quote
         {
             if let Ok(message) =


### PR DESCRIPTION
The latest version of the `ra-tls` crate from the `dstack` repository contains a fix needed to resolve https://github.com/flashbots/attested-tls/issues/30 following them merging https://github.com/Dstack-TEE/dstack/pull/673

This PR bumps `ra-tls` to the latest version and updates `attested-tls` for the new API.

We continue to use their V0 'legacy' attestation format so this is not a protocol breaking change.

Closes https://github.com/flashbots/attested-tls/issues/30