### PR TITLE
Add note to attestation crate readme that Azure support is currently unmaintained

### DIFF
--- a/crates/attestation/README.md
+++ b/crates/attestation/README.md
@@ -28,6 +28,11 @@ Tokio-backed background tasks such as PCCS pre-warm and cache refresh.
 Enables Microsoft Azure vTPM attestation support (generation and verification),
 through `tss-esapi`.
 
+**Note:** Azure support is currently **not actively maintained** as we do not
+have production CVMs deployed on Azure and so are unlikely to notice when this
+implementation of Azure attestation generation or verification ceases to work.
+Use at your own risk.
+
 This feature requires [tpm2](https://tpm2-software.github.io) and `openssl` to
 be installed. On Debian-based systems tpm2 is provided by
 [`libtss2-dev`](https://packages.debian.org/trixie/libtss2-dev), and on nix


### PR DESCRIPTION
This PR documents that Microsoft Azure attestation support is not currently actively maintained in the `attestation` crate readme.

This follows an issue where the Azure vTPM verification provided by this repo ceased to work with new Azure deployments and we were unaware because of not currently having any CVMs deployed on Azure.

cc: @Ruteri @samlaf    