### PR TITLE
Bump crates from attest repo following fix for counting disks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,12 +346,13 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "attest-measure"
 version = "0.0.1"
-source = "git+https://github.com/easy-tee/attest.git?rev=a64f147362b8948e2288015e476c40d04b11b661#a64f147362b8948e2288015e476c40d04b11b661"
+source = "git+https://github.com/easy-tee/attest.git?rev=8206cd19d9dcb1978d85a3d8dece06a3ee7a1206#8206cd19d9dcb1978d85a3d8dece06a3ee7a1206"
 dependencies = [
- "anyhow",
  "attest-types",
  "authenticode",
  "crc32fast",
+ "fatfs",
+ "flate2",
  "hex",
  "hex-literal",
  "object",
@@ -361,6 +362,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2",
+ "tar",
  "thiserror 2.0.18",
  "ureq 3.3.0",
  "x509-parser 0.18.1",
@@ -369,7 +371,7 @@ dependencies = [
 [[package]]
 name = "attest-types"
 version = "0.0.1"
-source = "git+https://github.com/easy-tee/attest.git?rev=a64f147362b8948e2288015e476c40d04b11b661#a64f147362b8948e2288015e476c40d04b11b661"
+source = "git+https://github.com/easy-tee/attest.git?rev=8206cd19d9dcb1978d85a3d8dece06a3ee7a1206#8206cd19d9dcb1978d85a3d8dece06a3ee7a1206"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1792,6 +1794,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fatfs"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05669f8e7e2d7badc545c513710f0eba09c2fbef683eb859fd79c46c355048e0"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "log",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,6 +1819,16 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -4662,6 +4685,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5820,6 +5854,16 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]

--- a/crates/attestation/Cargo.toml
+++ b/crates/attestation/Cargo.toml
@@ -13,8 +13,8 @@ pccs = { workspace = true }
 mock-tdx = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["fs", "rt", "rt-multi-thread"] }
 tokio-rustls = { workspace = true, default-features = false }
-attest-types = { git = "https://github.com/easy-tee/attest.git", rev = "a64f147362b8948e2288015e476c40d04b11b661" }
-attest-measure = {git = "https://github.com/easy-tee/attest.git", rev = "a64f147362b8948e2288015e476c40d04b11b661" }
+attest-types = { git = "https://github.com/easy-tee/attest.git", rev = "8206cd19d9dcb1978d85a3d8dece06a3ee7a1206" }
+attest-measure = {git = "https://github.com/easy-tee/attest.git", rev = "8206cd19d9dcb1978d85a3d8dece06a3ee7a1206" }
 
 anyhow = "1.0.100"
 pem-rfc7468 = { version = "0.7.0", features = ["std"] }

--- a/crates/attestation/src/gcp.rs
+++ b/crates/attestation/src/gcp.rs
@@ -49,14 +49,14 @@ pub(crate) fn fetch_firmware(mrtd: [u8; 48]) -> Result<DcapFirmware, GcpFirmware
         {
             tokio::task::block_in_place(|| {
                 handle.block_on(async move {
-                    tokio::task::spawn_blocking(move || DcapFirmware::from_google(mrtd))
+                    tokio::task::spawn_blocking(move || DcapFirmware::from_google(mrtd, None))
                         .await
                         .map_err(|err| GcpFirmwareCacheError::Join(err.to_string()))?
                         .map_err(GcpFirmwareCacheError::from)
                 })
             })
         }
-        _ => DcapFirmware::from_google(mrtd).map_err(GcpFirmwareCacheError::from),
+        _ => DcapFirmware::from_google(mrtd, None).map_err(GcpFirmwareCacheError::from),
     }
 }
 


### PR DESCRIPTION
This bumps crates `attest-types` and `attest-measure` to the head of main branch following merging https://github.com/Easy-TEE/attest/pull/21 which fixed https://github.com/Easy-TEE/attest/issues/20 - an issue with counting the number of disks present on a CVM.  It also updates for a small breaking API change in attest-measure.